### PR TITLE
Fix/latest block hash not found

### DIFF
--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -495,7 +495,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('confirmed')),
+      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
     }).add(swapTx);
   }
 
@@ -695,7 +695,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('confirmed')),
+      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
     }).add(depositTx);
   }
 
@@ -851,7 +851,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('confirmed')),
+      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
     }).add(withdrawTx);
   }
 

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -495,7 +495,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash()),
+      ...(await this.program.provider.connection.getLatestBlockhash('confirmed')),
     }).add(swapTx);
   }
 
@@ -695,7 +695,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash()),
+      ...(await this.program.provider.connection.getLatestBlockhash('confirmed')),
     }).add(depositTx);
   }
 
@@ -851,7 +851,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash()),
+      ...(await this.program.provider.connection.getLatestBlockhash('confirmed')),
     }).add(withdrawTx);
   }
 

--- a/ts-client/src/amm/tests/index.test.ts
+++ b/ts-client/src/amm/tests/index.test.ts
@@ -4,7 +4,6 @@ import { DEFAULT_SLIPPAGE, MAINNET_POOL, DEVNET_POOL } from '../constants';
 import { AnchorProvider, BN, Wallet } from '@project-serum/anchor';
 // import { airDropSol } from "./utils";
 import { bs58 } from '@project-serum/anchor/dist/cjs/utils/bytes';
-import { PoolInformation } from '../types';
 
 let mockWallet = new Wallet(
   process.env.WALLET_PRIVATE_KEY ? Keypair.fromSecretKey(bs58.decode(process.env.WALLET_PRIVATE_KEY)) : new Keypair(),


### PR DESCRIPTION
- getting error `Blockhash not found` when trying to execute transaction due to latest block hash could be missing if it's not confirmed.