### PR TITLE
refactor price impact calc to save computation

### DIFF
--- a/ts-client/src/amm/curve/index.ts
+++ b/ts-client/src/amm/curve/index.ts
@@ -1,5 +1,11 @@
 import { BN } from '@project-serum/anchor';
+import Decimal from 'decimal.js';
 import { PoolFees } from '../types';
+
+export interface OutResult {
+  outAmount: BN;
+  priceImpact: Decimal;
+}
 
 export interface SwapCurve {
   computeOutAmount(
@@ -7,7 +13,7 @@ export interface SwapCurve {
     swapSourceAmount: BN,
     swapDestinationAmount: BN,
     tradeDirection: TradeDirection,
-  ): BN;
+  ): OutResult;
 
   computeD(tokenAAmount: BN, tokenBAmount: BN): BN;
 
@@ -30,19 +36,17 @@ export interface SwapCurve {
     fees: PoolFees,
     tradeDirection: TradeDirection,
   ): BN;
-
-  computeOutAmountWithoutSlippage(
-    sourceAmount: BN,
-    swapSourceAmount: BN,
-    swapDestinationAmount: BN,
-    tradeDirection: TradeDirection,
-  ): BN;
 }
 
 export enum TradeDirection {
   AToB,
   BToA,
 }
+
+export const getPriceImpact = (amount: BN, amountWithoutSlippage: BN): Decimal => {
+  const diff = amountWithoutSlippage.sub(amount);
+  return new Decimal(diff.toString()).div(new Decimal(amountWithoutSlippage.toString()));
+};
 
 export * from './stable-swap';
 export * from './constant-product';

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -34,7 +34,6 @@ import {
   calculateSwapQuote,
   computeActualDepositAmount,
   calculatePoolInfo,
-  calculatePriceImpact,
   getMaxAmountWithSlippage,
   getMinAmountWithSlippage,
   getOrCreateATAInstruction,
@@ -385,29 +384,6 @@ export default class AmmImpl implements AmmImplementation {
     });
 
     return getMinAmountWithSlippage(swapQuote, slippage);
-  }
-
-  /**
-   * `getPriceImpact` returns the impact on the market price by the trade
-   * `inAmountLamport` of `inToken` into the pool
-   * @param {PublicKey} inTokenMint - The mint you want to swap from.
-   * @param {BN} inAmountLamport - The amount of lamports you want to swap.
-   * @returns The impact on the market price (* 100 for percentage unit)
-   */
-  public getPriceImpact(inTokenMint: PublicKey, inAmountLamport: BN) {
-    return calculatePriceImpact(inTokenMint, inAmountLamport, {
-      currentTime: this.accountsInfo.currentTime,
-      poolState: this.poolState,
-      depegAccounts: this.depegAccounts,
-      poolVaultALp: this.accountsInfo.poolVaultALp,
-      poolVaultBLp: this.accountsInfo.poolVaultBLp,
-      vaultA: this.vaultA.vaultState,
-      vaultB: this.vaultB.vaultState,
-      vaultALpSupply: this.accountsInfo.vaultALpSupply,
-      vaultBLpSupply: this.accountsInfo.vaultBLpSupply,
-      vaultAReserve: this.accountsInfo.vaultAReserve,
-      vaultBReserve: this.accountsInfo.vaultBReserve,
-    });
   }
 
   /**

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -5,6 +5,7 @@ import BN from 'bn.js';
 import { Amm as AmmIdl } from '../idl';
 import { IdlTypes } from '@project-serum/anchor/dist/esm';
 import { VaultState } from '@mercurial-finance/vault-sdk';
+import Decimal from 'decimal.js';
 
 export type AmmImplementation = {
   tokenA: TokenInfo;
@@ -49,6 +50,7 @@ export interface PoolFees {
 
 export interface SwapResult {
   amountOut: BN;
+  priceImpact: Decimal;
   fee: BN;
 }
 


### PR DESCRIPTION
- Save computation by avoid repeated calculation for `D`, `outAmount` and `upscaleToken` when calculate price impact