### PR TITLE
feat: Minor type changes and export CURVE_TYPE_ACCOUNTS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "mercurial-amm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/ts-client/index.ts
+++ b/ts-client/index.ts
@@ -1,6 +1,6 @@
 import AmmImpl from './src/amm';
 import { StableSwap, ConstantProductSwap } from './src/amm/curve';
-import { PROGRAM_ID, MAINNET_POOL, DEVNET_POOL } from './src/amm/constants';
+import { PROGRAM_ID, MAINNET_POOL, DEVNET_POOL, CURVE_TYPE_ACCOUNTS } from './src/amm/constants';
 import {
   getOnchainTime,
   calculateMaxSwapOutAmount,
@@ -26,6 +26,7 @@ export {
   PROGRAM_ID,
   MAINNET_POOL,
   DEVNET_POOL,
+  CURVE_TYPE_ACCOUNTS,
   // IDL
   AmmIdl,
   VaultIdl,

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@mercurial-finance/vault-sdk": "0.3.12",
     "@project-serum/anchor": "0.24.2",
-    "@saberhq/anchor-contrib": "^1.13.32",
-    "@saberhq/stableswap-sdk": "^1.13.32",
+    "@saberhq/anchor-contrib": "1.13.32",
+    "@saberhq/stableswap-sdk": "1.13.32",
     "@saberhq/token-utils": "1.13.32",
     "@solana/spl-token": "0.1.8",
     "@solana/spl-token-registry": "0.2.1105",

--- a/ts-client/pnpm-lock.yaml
+++ b/ts-client/pnpm-lock.yaml
@@ -3,8 +3,8 @@ lockfileVersion: 5.4
 specifiers:
   '@mercurial-finance/vault-sdk': 0.3.12
   '@project-serum/anchor': 0.24.2
-  '@saberhq/anchor-contrib': ^1.13.32
-  '@saberhq/stableswap-sdk': ^1.13.32
+  '@saberhq/anchor-contrib': 1.13.32
+  '@saberhq/stableswap-sdk': 1.13.32
   '@saberhq/token-utils': 1.13.32
   '@solana/buffer-layout': 4.0.0
   '@solana/spl-token': 0.1.8

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -71,7 +71,7 @@ const getAllPoolState = async (poolMints: Array<PublicKey>, program: AmmProgram)
 };
 
 const getPoolState = async (poolMint: PublicKey, program: AmmProgram) => {
-  const poolState = (await program.account.pool.fetchNullable(poolMint)) as PoolState;
+  const poolState = (await program.account.pool.fetchNullable(poolMint)) as any as PoolState;
   invariant(poolState, `Pool ${poolMint.toBase58()} not found`);
 
   const account = await program.provider.connection.getTokenSupply(poolState.lpMint);

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -43,13 +43,6 @@ export type WithdrawQuote = {
   tokenBOutAmount: BN;
 };
 
-export interface PoolFees {
-  tradeFeeNumerator: BN;
-  tradeFeeDenominator: BN;
-  ownerTradeFeeNumerator: BN;
-  ownerTradeFeeDenominator: BN;
-}
-
 export interface SwapResult {
   amountOut: BN;
   priceImpact: Decimal;
@@ -119,8 +112,9 @@ export interface TokenMultiplier {
   precisionFactor: number;
 }
 
-export type PoolState = Omit<IdlAccounts<AmmIdl>['pool'], 'curveType'> & { curveType: CurveType };
+export type PoolState = Omit<IdlAccounts<AmmIdl>['pool'], 'curveType'> & { curveType: CurveType; fees: PoolFees };
 export type Depeg = Omit<IdlTypes<AmmIdl>['Depeg'], 'depegType'> & { depegType: DepegType };
+export type PoolFees = IdlTypes<AmmIdl>['PoolFees'];
 export type VirtualPrice = IdlTypes<AmmIdl>['VirtualPrice'];
 export type SnapShot = IdlTypes<AmmIdl>['SnapShot'];
 export type ApyState = Omit<IdlAccounts<AmmIdl>['apy'], 'snapshot'> & { snapshot: SnapShot };

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -112,7 +112,10 @@ export interface TokenMultiplier {
   precisionFactor: number;
 }
 
-export type PoolState = Omit<IdlAccounts<AmmIdl>['pool'], 'curveType'> & { curveType: CurveType; fees: PoolFees };
+export type PoolState = Omit<IdlAccounts<AmmIdl>['pool'], 'curveType' | 'fees'> & {
+  curveType: CurveType;
+  fees: PoolFees;
+};
 export type Depeg = Omit<IdlTypes<AmmIdl>['Depeg'], 'depegType'> & { depegType: DepegType };
 export type PoolFees = IdlTypes<AmmIdl>['PoolFees'];
 export type VirtualPrice = IdlTypes<AmmIdl>['VirtualPrice'];

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -1,13 +1,12 @@
 import { AccountInfo, PublicKey, Transaction } from '@solana/web3.js';
 import { TokenInfo } from '@solana/spl-token-registry';
-import { TypeDef } from '@project-serum/anchor/dist/cjs/program/namespace/types';
+import { IdlAccounts, IdlTypes } from '@project-serum/anchor';
 import BN from 'bn.js';
 import { Amm as AmmIdl } from '../idl';
-import { IdlTypes } from '@project-serum/anchor/dist/esm';
 import { VaultState } from '@mercurial-finance/vault-sdk';
 import Decimal from 'decimal.js';
 
-export type AmmImplementation = {
+export interface AmmImplementation {
   tokenA: TokenInfo;
   tokenB: TokenInfo;
   decimals: number;
@@ -27,7 +26,7 @@ export type AmmImplementation = {
     tokenAOutAmount: BN,
     tokenBOutAmount: BN,
   ) => Promise<Transaction>;
-};
+}
 
 export type DepositQuote = {
   poolTokenAmountOut: BN;
@@ -86,6 +85,8 @@ export enum AccountType {
   SYSVAR_CLOCK = 'sysClockVar',
 }
 
+export type CurveType = ConstantProductCurve | StableSwapCurve;
+
 export type StableSwapCurve = {
   stable: {
     amp: BN;
@@ -112,22 +113,17 @@ export type DepegLido = {
 
 export type DepegType = DepegNone | DepegMarinade | DepegLido;
 
-export type Depeg = {
-  baseVirtualPrice: BN;
-  baseCacheUpdated: BN;
-  depegType: DepegType;
-};
-
 export interface TokenMultiplier {
   tokenAMultiplier: BN;
   tokenBMultiplier: BN;
   precisionFactor: number;
 }
 
-// PoolState
-export type PoolState = TypeDef<AmmIdl['accounts']['0'], IdlTypes<AmmIdl>>;
-export type VirtualPrice = TypeDef<AmmIdl['types']['4'], IdlTypes<AmmIdl>>;
-export type ApyState = TypeDef<AmmIdl['accounts']['1'], IdlTypes<AmmIdl>>;
+export type PoolState = Omit<IdlAccounts<AmmIdl>['pool'], 'curveType'> & { curveType: CurveType };
+export type Depeg = Omit<IdlTypes<AmmIdl>['Depeg'], 'depegType'> & { depegType: DepegType };
+export type VirtualPrice = IdlTypes<AmmIdl>['VirtualPrice'];
+export type SnapShot = IdlTypes<AmmIdl>['SnapShot'];
+export type ApyState = Omit<IdlAccounts<AmmIdl>['apy'], 'snapshot'> & { snapshot: SnapShot };
 
 export type PoolInformation = {
   firstTimestamp: BN;


### PR DESCRIPTION
If CURVE_TYPE_ACCOUNTS is exported we can use it in Jupiter so depeg account can be read there, we can still import from dist but it is weird.

For https://github.com/mercurial-finance/monorepo/pull/2559