### PR TITLE
feat: add lock escrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## @mercurial-finance/dynamic-amm-sdk [0.4.21] - PR #117
 
 ### Added
-- New lock escrow mechanism supported by program
-- `AmmImpl.getLockedAtaAmount`: get locked lp amounts from ata mechanism (old mechanism)
-- `AmmImpl.getLockedLpAmount`: get locked lp amounts on 2 versions of locking: ata (old) and escrow (new), then sum them
-- `AmmImpl.getUserLockEscrow`: get user's lock escrow state
-- `AmmImpl.lockLiquidity`: do lock user's lp into lock escrow
-- `AmmImpl.claimLockFee`: do claim fee from locked lps in lock escrow
+- Introduced a new lock escrow mechanism supported by the program.
+- `AmmImpl.getLockedAtaAmount` to retrieve locked LP amounts from the ATA mechanism (old mechanism).
+- `AmmImpl.getLockedLpAmount` to fetch locked LP amounts from two versions of locking: ATA (old) and escrow (new), and then sum them.
+- `AmmImpl.getUserLockEscrow` to obtain the user's lock escrow state.
+- `AmmImpl.lockLiquidity` to lock the user's LP into the lock escrow.
+- `AmmImpl.claimLockFee` to claim fees from locked LPs in the lock escrow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+
+## @mercurial-finance/dynamic-amm-sdk [0.4.21] - PR #117
+
+### Added
+- New lock escrow mechanism supported by program
+- `AmmImpl.getLockedAtaAmount`: get locked lp amounts from ata mechanism (old mechanism)
+- `AmmImpl.getLockedLpAmount`: get locked lp amounts on 2 versions of locking: ata (old) and escrow (new), then sum them
+- `AmmImpl.getUserLockEscrow`: get user's lock escrow state
+- `AmmImpl.lockLiquidity`: do lock user's lp into lock escrow
+- `AmmImpl.claimLockFee`: do claim fee from locked lps in lock escrow

--- a/ts-client/index.ts
+++ b/ts-client/index.ts
@@ -55,6 +55,7 @@ export type {
   WithdrawQuote,
   SwapQuote,
   PoolState,
+  LockEscrow,
   PoolInformation,
   ParsedClockState,
   ConstantProductCurve,

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.5",
+  "version": "0.4.21-rc.6",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.4",
+  "version": "0.4.21-rc.5",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.1",
+  "version": "0.4.21-rc.2",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.20",
+  "version": "0.4.21-rc.1",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.10",
+  "version": "0.4.21",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.8",
+  "version": "0.4.21-rc.10",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.2",
+  "version": "0.4.21-rc.3",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.6",
+  "version": "0.4.21-rc.8",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.4.21-rc.3",
+  "version": "0.4.21-rc.4",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/src/amm/constants.ts
+++ b/ts-client/src/amm/constants.ts
@@ -100,6 +100,7 @@ export const SEEDS = Object.freeze({
   APY: 'apy',
   FEE: 'fee',
   LP_MINT: 'lp_mint',
+  LOCK_ESCROW: 'lock_escrow',
 });
 
 export const VAULT_BASE_KEY = new PublicKey('HWzXGcGHy4tcpYfaRDCyLNzXqBTv3E6BttpCH2vJxArv');

--- a/ts-client/src/amm/idl.ts
+++ b/ts-client/src/amm/idl.ts
@@ -1,5 +1,5 @@
 export type Amm = {
-  version: '0.4.12';
+  version: '0.5.0';
   name: 'amm';
   docs: ['Program for AMM'];
   instructions: [
@@ -2874,7 +2874,7 @@ export type Amm = {
 };
 
 export const IDL: Amm = {
-  version: '0.4.12',
+  version: '0.5.0',
   name: 'amm',
   docs: ['Program for AMM'],
   instructions: [

--- a/ts-client/src/amm/idl.ts
+++ b/ts-client/src/amm/idl.ts
@@ -1546,6 +1546,270 @@ export type Amm = {
       ];
       args: [];
     },
+    {
+      name: 'createLockEscrow';
+      docs: ['Create lock account'];
+      accounts: [
+        {
+          name: 'pool';
+          isMut: false;
+          isSigner: false;
+          docs: ['Pool account'];
+        },
+        {
+          name: 'lockEscrow';
+          isMut: true;
+          isSigner: false;
+          docs: ['Lock account'];
+        },
+        {
+          name: 'owner';
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: 'lpMint';
+          isMut: false;
+          isSigner: false;
+          docs: ['LP token mint of the pool'];
+        },
+        {
+          name: 'payer';
+          isMut: true;
+          isSigner: true;
+          docs: ['Payer account'];
+        },
+        {
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
+          docs: ['System program.'];
+        },
+      ];
+      args: [];
+    },
+    {
+      name: 'lock';
+      docs: ['Lock Lp token'];
+      accounts: [
+        {
+          name: 'pool';
+          isMut: true;
+          isSigner: false;
+          docs: ['Pool account'];
+        },
+        {
+          name: 'lpMint';
+          isMut: false;
+          isSigner: false;
+          docs: ['LP token mint of the pool'];
+        },
+        {
+          name: 'lockEscrow';
+          isMut: true;
+          isSigner: false;
+          docs: ['Lock account'];
+        },
+        {
+          name: 'owner';
+          isMut: true;
+          isSigner: true;
+          docs: ['Owner of lock account'];
+        },
+        {
+          name: 'sourceTokens';
+          isMut: true;
+          isSigner: false;
+          docs: ['owner lp token account'];
+        },
+        {
+          name: 'escrowVault';
+          isMut: true;
+          isSigner: false;
+          docs: ['Escrow vault'];
+        },
+        {
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
+          docs: ['Token program.'];
+        },
+        {
+          name: 'aVault';
+          isMut: false;
+          isSigner: false;
+          docs: ['Vault account for token a. token a of the pool will be deposit / withdraw from this vault account.'];
+        },
+        {
+          name: 'bVault';
+          isMut: false;
+          isSigner: false;
+          docs: ['Vault account for token b. token b of the pool will be deposit / withdraw from this vault account.'];
+        },
+        {
+          name: 'aVaultLp';
+          isMut: false;
+          isSigner: false;
+          docs: [
+            'LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ];
+        },
+        {
+          name: 'bVaultLp';
+          isMut: false;
+          isSigner: false;
+          docs: [
+            'LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ];
+        },
+        {
+          name: 'aVaultLpMint';
+          isMut: false;
+          isSigner: false;
+          docs: ['LP token mint of vault a'];
+        },
+        {
+          name: 'bVaultLpMint';
+          isMut: false;
+          isSigner: false;
+          docs: ['LP token mint of vault b'];
+        },
+      ];
+      args: [
+        {
+          name: 'amount';
+          type: 'u64';
+        },
+      ];
+    },
+    {
+      name: 'claimFee';
+      docs: ['Claim fee'];
+      accounts: [
+        {
+          name: 'pool';
+          isMut: true;
+          isSigner: false;
+          docs: ['Pool account'];
+        },
+        {
+          name: 'lpMint';
+          isMut: true;
+          isSigner: false;
+          docs: ['LP token mint of the pool'];
+        },
+        {
+          name: 'lockEscrow';
+          isMut: true;
+          isSigner: false;
+          docs: ['Lock account'];
+        },
+        {
+          name: 'owner';
+          isMut: true;
+          isSigner: true;
+          docs: ['Owner of lock account'];
+        },
+        {
+          name: 'sourceTokens';
+          isMut: true;
+          isSigner: false;
+          docs: ['owner lp token account'];
+        },
+        {
+          name: 'escrowVault';
+          isMut: true;
+          isSigner: false;
+          docs: ['Escrow vault'];
+        },
+        {
+          name: 'tokenProgram';
+          isMut: false;
+          isSigner: false;
+          docs: ['Token program.'];
+        },
+        {
+          name: 'aTokenVault';
+          isMut: true;
+          isSigner: false;
+          docs: ['Token vault account of vault A'];
+        },
+        {
+          name: 'bTokenVault';
+          isMut: true;
+          isSigner: false;
+          docs: ['Token vault account of vault B'];
+        },
+        {
+          name: 'aVault';
+          isMut: true;
+          isSigner: false;
+          docs: ['Vault account for token a. token a of the pool will be deposit / withdraw from this vault account.'];
+        },
+        {
+          name: 'bVault';
+          isMut: true;
+          isSigner: false;
+          docs: ['Vault account for token b. token b of the pool will be deposit / withdraw from this vault account.'];
+        },
+        {
+          name: 'aVaultLp';
+          isMut: true;
+          isSigner: false;
+          docs: [
+            'LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ];
+        },
+        {
+          name: 'bVaultLp';
+          isMut: true;
+          isSigner: false;
+          docs: [
+            'LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ];
+        },
+        {
+          name: 'aVaultLpMint';
+          isMut: true;
+          isSigner: false;
+          docs: ['LP token mint of vault a'];
+        },
+        {
+          name: 'bVaultLpMint';
+          isMut: true;
+          isSigner: false;
+          docs: ['LP token mint of vault b'];
+        },
+        {
+          name: 'userAToken';
+          isMut: true;
+          isSigner: false;
+          docs: [
+            'User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account.',
+          ];
+        },
+        {
+          name: 'userBToken';
+          isMut: true;
+          isSigner: false;
+          docs: [
+            'User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account.',
+          ];
+        },
+        {
+          name: 'vaultProgram';
+          isMut: false;
+          isSigner: false;
+          docs: ['Vault program. the pool will deposit/withdraw liquidity from the vault.'];
+        },
+      ];
+      args: [
+        {
+          name: 'maxAmount';
+          type: 'u64';
+        },
+      ];
+    },
   ];
   accounts: [
     {
@@ -1642,6 +1906,11 @@ export type Amm = {
             type: 'publicKey';
           },
           {
+            name: 'totalLockedLp';
+            docs: ['Total locked lp token'];
+            type: 'u64';
+          },
+          {
             name: 'padding';
             docs: ['Padding for future pool field'];
             type: {
@@ -1654,6 +1923,60 @@ export type Amm = {
             type: {
               defined: 'CurveType';
             };
+          },
+        ];
+      };
+    },
+    {
+      name: 'lockEscrow';
+      docs: ['State of lock escrow account'];
+      type: {
+        kind: 'struct';
+        fields: [
+          {
+            name: 'pool';
+            docs: ['Pool address'];
+            type: 'publicKey';
+          },
+          {
+            name: 'owner';
+            docs: ['Owner address'];
+            type: 'publicKey';
+          },
+          {
+            name: 'escrowVault';
+            docs: ['Vault address, store the lock user lock'];
+            type: 'publicKey';
+          },
+          {
+            name: 'bump';
+            docs: ['bump, used to sign'];
+            type: 'u8';
+          },
+          {
+            name: 'totalLockedAmount';
+            docs: ['Total locked amount'];
+            type: 'u64';
+          },
+          {
+            name: 'lpPerToken';
+            docs: ['Lp per token, virtual price of lp token'];
+            type: 'u128';
+          },
+          {
+            name: 'unclaimedFeePending';
+            docs: ['Unclaimed fee pending'];
+            type: 'u64';
+          },
+          {
+            name: 'aFee';
+            docs: ['Total a fee claimed so far'];
+            type: 'u64';
+          },
+          {
+            name: 'bFee';
+            docs: ['Total b fee claimed so far'];
+            type: 'u64';
           },
         ];
       };
@@ -1760,7 +2083,7 @@ export type Amm = {
             name: 'padding0';
             docs: ['Padding 0'];
             type: {
-              array: ['u8', 15];
+              array: ['u8', 7];
             };
           },
           {
@@ -1932,6 +2255,21 @@ export type Amm = {
       };
     },
     {
+      name: 'Rounding';
+      docs: ['Round up, down'];
+      type: {
+        kind: 'enum';
+        variants: [
+          {
+            name: 'Up';
+          },
+          {
+            name: 'Down';
+          },
+        ];
+      };
+    },
+    {
       name: 'PoolType';
       docs: ['Pool type'];
       type: {
@@ -1989,6 +2327,31 @@ export type Amm = {
       ];
     },
     {
+      name: 'BootstrapLiquidity';
+      fields: [
+        {
+          name: 'lpMintAmount';
+          type: 'u64';
+          index: false;
+        },
+        {
+          name: 'tokenAAmount';
+          type: 'u64';
+          index: false;
+        },
+        {
+          name: 'tokenBAmount';
+          type: 'u64';
+          index: false;
+        },
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+      ];
+    },
+    {
       name: 'Swap';
       fields: [
         {
@@ -2041,6 +2404,11 @@ export type Amm = {
           type: 'u64';
           index: false;
         },
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
       ];
     },
     {
@@ -2081,6 +2449,11 @@ export type Amm = {
           type: 'publicKey';
           index: false;
         },
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
       ];
     },
     {
@@ -2118,6 +2491,153 @@ export type Amm = {
         },
         {
           name: 'updatedTimestamp';
+          type: 'u64';
+          index: false;
+        },
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+      ];
+    },
+    {
+      name: 'PoolCreated';
+      fields: [
+        {
+          name: 'lpMint';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'tokenAMint';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'tokenBMint';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'poolType';
+          type: {
+            defined: 'PoolType';
+          };
+          index: false;
+        },
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+      ];
+    },
+    {
+      name: 'PoolEnabled';
+      fields: [
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'enabled';
+          type: 'bool';
+          index: false;
+        },
+      ];
+    },
+    {
+      name: 'MigrateFeeAccount';
+      fields: [
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'newAdminTokenAFee';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'newAdminTokenBFee';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'tokenAAmount';
+          type: 'u64';
+          index: false;
+        },
+        {
+          name: 'tokenBAmount';
+          type: 'u64';
+          index: false;
+        },
+      ];
+    },
+    {
+      name: 'CreateLockEscrow';
+      fields: [
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'owner';
+          type: 'publicKey';
+          index: false;
+        },
+      ];
+    },
+    {
+      name: 'Lock';
+      fields: [
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'owner';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'amount';
+          type: 'u64';
+          index: false;
+        },
+      ];
+    },
+    {
+      name: 'ClaimFee';
+      fields: [
+        {
+          name: 'pool';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'owner';
+          type: 'publicKey';
+          index: false;
+        },
+        {
+          name: 'amount';
+          type: 'u64';
+          index: false;
+        },
+        {
+          name: 'aFee';
+          type: 'u64';
+          index: false;
+        },
+        {
+          name: 'bFee';
           type: 'u64';
           index: false;
         },
@@ -2334,6 +2854,21 @@ export type Amm = {
       code: 6041;
       name: 'AmountNotPeg';
       msg: 'Token amount is not 1:1';
+    },
+    {
+      code: 6042;
+      name: 'AmountIsZero';
+      msg: 'Amount is zero';
+    },
+    {
+      code: 6043;
+      name: 'TypeCastFailed';
+      msg: 'Type cast error';
+    },
+    {
+      code: 6044;
+      name: 'AmountIsNotEnough';
+      msg: 'Amount is not enough';
     },
   ];
 };
@@ -3886,6 +4421,270 @@ export const IDL: Amm = {
       ],
       args: [],
     },
+    {
+      name: 'createLockEscrow',
+      docs: ['Create lock account'],
+      accounts: [
+        {
+          name: 'pool',
+          isMut: false,
+          isSigner: false,
+          docs: ['Pool account'],
+        },
+        {
+          name: 'lockEscrow',
+          isMut: true,
+          isSigner: false,
+          docs: ['Lock account'],
+        },
+        {
+          name: 'owner',
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: 'lpMint',
+          isMut: false,
+          isSigner: false,
+          docs: ['LP token mint of the pool'],
+        },
+        {
+          name: 'payer',
+          isMut: true,
+          isSigner: true,
+          docs: ['Payer account'],
+        },
+        {
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
+          docs: ['System program.'],
+        },
+      ],
+      args: [],
+    },
+    {
+      name: 'lock',
+      docs: ['Lock Lp token'],
+      accounts: [
+        {
+          name: 'pool',
+          isMut: true,
+          isSigner: false,
+          docs: ['Pool account'],
+        },
+        {
+          name: 'lpMint',
+          isMut: false,
+          isSigner: false,
+          docs: ['LP token mint of the pool'],
+        },
+        {
+          name: 'lockEscrow',
+          isMut: true,
+          isSigner: false,
+          docs: ['Lock account'],
+        },
+        {
+          name: 'owner',
+          isMut: true,
+          isSigner: true,
+          docs: ['Owner of lock account'],
+        },
+        {
+          name: 'sourceTokens',
+          isMut: true,
+          isSigner: false,
+          docs: ['owner lp token account'],
+        },
+        {
+          name: 'escrowVault',
+          isMut: true,
+          isSigner: false,
+          docs: ['Escrow vault'],
+        },
+        {
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
+          docs: ['Token program.'],
+        },
+        {
+          name: 'aVault',
+          isMut: false,
+          isSigner: false,
+          docs: ['Vault account for token a. token a of the pool will be deposit / withdraw from this vault account.'],
+        },
+        {
+          name: 'bVault',
+          isMut: false,
+          isSigner: false,
+          docs: ['Vault account for token b. token b of the pool will be deposit / withdraw from this vault account.'],
+        },
+        {
+          name: 'aVaultLp',
+          isMut: false,
+          isSigner: false,
+          docs: [
+            'LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ],
+        },
+        {
+          name: 'bVaultLp',
+          isMut: false,
+          isSigner: false,
+          docs: [
+            'LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ],
+        },
+        {
+          name: 'aVaultLpMint',
+          isMut: false,
+          isSigner: false,
+          docs: ['LP token mint of vault a'],
+        },
+        {
+          name: 'bVaultLpMint',
+          isMut: false,
+          isSigner: false,
+          docs: ['LP token mint of vault b'],
+        },
+      ],
+      args: [
+        {
+          name: 'amount',
+          type: 'u64',
+        },
+      ],
+    },
+    {
+      name: 'claimFee',
+      docs: ['Claim fee'],
+      accounts: [
+        {
+          name: 'pool',
+          isMut: true,
+          isSigner: false,
+          docs: ['Pool account'],
+        },
+        {
+          name: 'lpMint',
+          isMut: true,
+          isSigner: false,
+          docs: ['LP token mint of the pool'],
+        },
+        {
+          name: 'lockEscrow',
+          isMut: true,
+          isSigner: false,
+          docs: ['Lock account'],
+        },
+        {
+          name: 'owner',
+          isMut: true,
+          isSigner: true,
+          docs: ['Owner of lock account'],
+        },
+        {
+          name: 'sourceTokens',
+          isMut: true,
+          isSigner: false,
+          docs: ['owner lp token account'],
+        },
+        {
+          name: 'escrowVault',
+          isMut: true,
+          isSigner: false,
+          docs: ['Escrow vault'],
+        },
+        {
+          name: 'tokenProgram',
+          isMut: false,
+          isSigner: false,
+          docs: ['Token program.'],
+        },
+        {
+          name: 'aTokenVault',
+          isMut: true,
+          isSigner: false,
+          docs: ['Token vault account of vault A'],
+        },
+        {
+          name: 'bTokenVault',
+          isMut: true,
+          isSigner: false,
+          docs: ['Token vault account of vault B'],
+        },
+        {
+          name: 'aVault',
+          isMut: true,
+          isSigner: false,
+          docs: ['Vault account for token a. token a of the pool will be deposit / withdraw from this vault account.'],
+        },
+        {
+          name: 'bVault',
+          isMut: true,
+          isSigner: false,
+          docs: ['Vault account for token b. token b of the pool will be deposit / withdraw from this vault account.'],
+        },
+        {
+          name: 'aVaultLp',
+          isMut: true,
+          isSigner: false,
+          docs: [
+            'LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ],
+        },
+        {
+          name: 'bVaultLp',
+          isMut: true,
+          isSigner: false,
+          docs: [
+            'LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault.',
+          ],
+        },
+        {
+          name: 'aVaultLpMint',
+          isMut: true,
+          isSigner: false,
+          docs: ['LP token mint of vault a'],
+        },
+        {
+          name: 'bVaultLpMint',
+          isMut: true,
+          isSigner: false,
+          docs: ['LP token mint of vault b'],
+        },
+        {
+          name: 'userAToken',
+          isMut: true,
+          isSigner: false,
+          docs: [
+            'User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account.',
+          ],
+        },
+        {
+          name: 'userBToken',
+          isMut: true,
+          isSigner: false,
+          docs: [
+            'User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account.',
+          ],
+        },
+        {
+          name: 'vaultProgram',
+          isMut: false,
+          isSigner: false,
+          docs: ['Vault program. the pool will deposit/withdraw liquidity from the vault.'],
+        },
+      ],
+      args: [
+        {
+          name: 'maxAmount',
+          type: 'u64',
+        },
+      ],
+    },
   ],
   accounts: [
     {
@@ -3982,6 +4781,11 @@ export const IDL: Amm = {
             type: 'publicKey',
           },
           {
+            name: 'totalLockedLp',
+            docs: ['Total locked lp token'],
+            type: 'u64',
+          },
+          {
             name: 'padding',
             docs: ['Padding for future pool field'],
             type: {
@@ -3994,6 +4798,60 @@ export const IDL: Amm = {
             type: {
               defined: 'CurveType',
             },
+          },
+        ],
+      },
+    },
+    {
+      name: 'lockEscrow',
+      docs: ['State of lock escrow account'],
+      type: {
+        kind: 'struct',
+        fields: [
+          {
+            name: 'pool',
+            docs: ['Pool address'],
+            type: 'publicKey',
+          },
+          {
+            name: 'owner',
+            docs: ['Owner address'],
+            type: 'publicKey',
+          },
+          {
+            name: 'escrowVault',
+            docs: ['Vault address, store the lock user lock'],
+            type: 'publicKey',
+          },
+          {
+            name: 'bump',
+            docs: ['bump, used to sign'],
+            type: 'u8',
+          },
+          {
+            name: 'totalLockedAmount',
+            docs: ['Total locked amount'],
+            type: 'u64',
+          },
+          {
+            name: 'lpPerToken',
+            docs: ['Lp per token, virtual price of lp token'],
+            type: 'u128',
+          },
+          {
+            name: 'unclaimedFeePending',
+            docs: ['Unclaimed fee pending'],
+            type: 'u64',
+          },
+          {
+            name: 'aFee',
+            docs: ['Total a fee claimed so far'],
+            type: 'u64',
+          },
+          {
+            name: 'bFee',
+            docs: ['Total b fee claimed so far'],
+            type: 'u64',
           },
         ],
       },
@@ -4100,7 +4958,7 @@ export const IDL: Amm = {
             name: 'padding0',
             docs: ['Padding 0'],
             type: {
-              array: ['u8', 15],
+              array: ['u8', 7],
             },
           },
           {
@@ -4272,6 +5130,21 @@ export const IDL: Amm = {
       },
     },
     {
+      name: 'Rounding',
+      docs: ['Round up, down'],
+      type: {
+        kind: 'enum',
+        variants: [
+          {
+            name: 'Up',
+          },
+          {
+            name: 'Down',
+          },
+        ],
+      },
+    },
+    {
       name: 'PoolType',
       docs: ['Pool type'],
       type: {
@@ -4329,6 +5202,31 @@ export const IDL: Amm = {
       ],
     },
     {
+      name: 'BootstrapLiquidity',
+      fields: [
+        {
+          name: 'lpMintAmount',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'tokenAAmount',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'tokenBAmount',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+      ],
+    },
+    {
       name: 'Swap',
       fields: [
         {
@@ -4381,6 +5279,11 @@ export const IDL: Amm = {
           type: 'u64',
           index: false,
         },
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
       ],
     },
     {
@@ -4421,6 +5324,11 @@ export const IDL: Amm = {
           type: 'publicKey',
           index: false,
         },
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
       ],
     },
     {
@@ -4458,6 +5366,153 @@ export const IDL: Amm = {
         },
         {
           name: 'updatedTimestamp',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'PoolCreated',
+      fields: [
+        {
+          name: 'lpMint',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'tokenAMint',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'tokenBMint',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'poolType',
+          type: {
+            defined: 'PoolType',
+          },
+          index: false,
+        },
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'PoolEnabled',
+      fields: [
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'enabled',
+          type: 'bool',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'MigrateFeeAccount',
+      fields: [
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'newAdminTokenAFee',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'newAdminTokenBFee',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'tokenAAmount',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'tokenBAmount',
+          type: 'u64',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'CreateLockEscrow',
+      fields: [
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'owner',
+          type: 'publicKey',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'Lock',
+      fields: [
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'owner',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'amount',
+          type: 'u64',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'ClaimFee',
+      fields: [
+        {
+          name: 'pool',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'owner',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'amount',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'aFee',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'bFee',
           type: 'u64',
           index: false,
         },
@@ -4674,6 +5729,21 @@ export const IDL: Amm = {
       code: 6041,
       name: 'AmountNotPeg',
       msg: 'Token amount is not 1:1',
+    },
+    {
+      code: 6042,
+      name: 'AmountIsZero',
+      msg: 'Amount is zero',
+    },
+    {
+      code: 6043,
+      name: 'TypeCastFailed',
+      msg: 'Type cast error',
+    },
+    {
+      code: 6044,
+      name: 'AmountIsNotEnough',
+      msg: 'Amount is not enough',
     },
   ],
 };

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -1375,8 +1375,6 @@ export default class AmmImpl implements AmmImplementation {
       address: lockEscrow,
       amount: lockEscrowAccount.totalLockedAmount || new BN(0),
       fee: {
-        tokenAMint: lockEscrowAccount.tokenAMint,
-        tokenBMint: lockEscrowAccount.tokenBMint,
         claimed: {
           tokenA: lockEscrowAccount.aFee || new BN(0),
           tokenB: lockEscrowAccount.bFee || new BN(0),

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -1404,8 +1404,8 @@ export default class AmmImpl implements AmmImplementation {
     }
 
     const [[userAta, createUserAtaIx], [escrowAta, createEscrowAtaIx]] = await Promise.all([
-      getOrCreateATAInstruction(this.poolState.lpMint, owner, this.program.provider.connection),
-      getOrCreateATAInstruction(this.poolState.lpMint, lockEscrowPK, this.program.provider.connection),
+      getOrCreateATAInstruction(this.poolState.lpMint, owner, this.program.provider.connection, owner),
+      getOrCreateATAInstruction(this.poolState.lpMint, lockEscrowPK, this.program.provider.connection, owner),
     ]);
 
     createUserAtaIx && preInstructions.push(createUserAtaIx);

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -1378,12 +1378,12 @@ export default class AmmImpl implements AmmImplementation {
         tokenAMint: lockEscrowAccount.tokenAMint,
         tokenBMint: lockEscrowAccount.tokenBMint,
         claimed: {
-          tokenAFee: lockEscrowAccount.aFee || new BN(0),
-          tokenBFee: lockEscrowAccount.bFee || new BN(0),
+          tokenA: lockEscrowAccount.aFee || new BN(0),
+          tokenB: lockEscrowAccount.bFee || new BN(0),
         },
         unClaimed: {
-          tokenAFee: tokenAOutAmount,
-          tokenBFee: tokenBOutAmount,
+          tokenA: tokenAOutAmount,
+          tokenB: tokenBOutAmount,
         },
       },
     };
@@ -1485,7 +1485,10 @@ export default class AmmImpl implements AmmImplementation {
       })
       .preInstructions(preInstructions)
       .transaction();
-    return tx;
+    return new Transaction({
+      feePayer: owner,
+      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
+    }).add(tx);
   }
 
   private async createATAPreInstructions(owner: PublicKey, mintList: Array<PublicKey>) {

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -297,7 +297,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: payer,
-      ...(await ammProgram.provider.connection.getLatestBlockhash('finalized')),
+      ...(await ammProgram.provider.connection.getLatestBlockhash(ammProgram.provider.connection.commitment)),
     }).add(createPermissionlessPoolTx);
   }
 
@@ -950,7 +950,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
+      ...(await this.program.provider.connection.getLatestBlockhash(this.program.provider.connection.commitment)),
     }).add(swapTx);
   }
 
@@ -1185,7 +1185,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
+      ...(await this.program.provider.connection.getLatestBlockhash(this.program.provider.connection.commitment)),
     }).add(depositTx);
   }
 
@@ -1355,7 +1355,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
+      ...(await this.program.provider.connection.getLatestBlockhash(this.program.provider.connection.commitment)),
     }).add(withdrawTx);
   }
 
@@ -1437,7 +1437,7 @@ export default class AmmImpl implements AmmImplementation {
 
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
+      ...(await this.program.provider.connection.getLatestBlockhash(this.program.provider.connection.commitment)),
     }).add(lockTx);
   }
 
@@ -1494,7 +1494,7 @@ export default class AmmImpl implements AmmImplementation {
       .transaction();
     return new Transaction({
       feePayer: owner,
-      ...(await this.program.provider.connection.getLatestBlockhash('finalized')),
+      ...(await this.program.provider.connection.getLatestBlockhash(this.program.provider.connection.commitment)),
     }).add(tx);
   }
 

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -1382,8 +1382,8 @@ export default class AmmImpl implements AmmImplementation {
           tokenB: lockEscrowAccount.bFee || new BN(0),
         },
         unClaimed: {
-          tokenA: tokenAOutAmount,
-          tokenB: tokenBOutAmount,
+          tokenA: tokenAOutAmount || new BN(0),
+          tokenB: tokenBOutAmount || new BN(0),
         },
       },
     };

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -1387,7 +1387,7 @@ export default class AmmImpl implements AmmImplementation {
 
   public async getUserLockEscrow(owner: PublicKey): Promise<LockEscrow | null> {
     const [lockEscrow, _lockEscrowBump] = deriveLockEscrowPda(this.address, owner, this.program.programId);
-    const lockEscrowAccount: LockEscrowProgram | null = await this.program.account.lockEscrow.fetchNullable(lockEscrow);
+    const lockEscrowAccount: LockEscrowAccount | null = await this.program.account.lockEscrow.fetchNullable(lockEscrow);
     if (!lockEscrowAccount) return null;
     const unClaimedFee = calculateUnclaimedLockEscrowFee(
       lockEscrowAccount.totalLockedAmount,

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -1461,6 +1461,12 @@ export default class AmmImpl implements AmmImplementation {
     createTokenAAtaIx && preInstructions.push(createTokenAAtaIx);
     createTokenBAtaIx && preInstructions.push(createTokenBAtaIx);
 
+    const postInstructions: Array<TransactionInstruction> = [];
+    if ([this.poolState.tokenAMint.toBase58(), this.poolState.tokenBMint.toBase58()].includes(NATIVE_MINT.toBase58())) {
+      const closeWrappedSOLIx = await unwrapSOLInstruction(owner);
+      closeWrappedSOLIx && postInstructions.push(closeWrappedSOLIx);
+    }
+
     const tx = await this.program.methods
       .claimFee(maxAmount)
       .accounts({
@@ -1484,6 +1490,7 @@ export default class AmmImpl implements AmmImplementation {
         userBToken: tokenBAta,
       })
       .preInstructions(preInstructions)
+      .postInstructions(postInstructions)
       .transaction();
     return new Transaction({
       feePayer: owner,

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -30,6 +30,7 @@ import {
   AmmProgram,
   DepositQuote,
   LockEscrow,
+  LockEscrowProgram,
   PoolInformation,
   PoolState,
   VaultProgram,
@@ -1361,7 +1362,7 @@ export default class AmmImpl implements AmmImplementation {
 
   public async getUserLockEscrow(owner: PublicKey): Promise<LockEscrow | null> {
     const [lockEscrow, _lockEscrowBump] = deriveLockEscrowPda(this.address, owner, this.program.programId);
-    const lockEscrowAccount = await this.program.account.lockEscrow.fetchNullable(lockEscrow);
+    const lockEscrowAccount: LockEscrowProgram | null = await this.program.account.lockEscrow.fetchNullable(lockEscrow);
     if (!lockEscrowAccount) return null;
     const unClaimedFee = calculateUnclaimedLockEscrowFee(
       lockEscrowAccount.totalLockedAmount,

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -34,8 +34,8 @@ export interface AmmImplementation {
 }
 
 type Fees = {
-  tokenAFee: BN;
-  tokenBFee: BN;
+  tokenA: BN;
+  tokenB: BN;
 };
 
 export interface LockEscrow {

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -41,12 +41,11 @@ type Fees = {
 export interface LockEscrow {
   address: PublicKey;
   amount: BN;
-  tokenAMint: PublicKey;
-  tokenBMint: PublicKey;
   fee: {
+    tokenAMint: PublicKey;
+    tokenBMint: PublicKey;
     claimed: Fees;
-    toBeClaim: Fees;
-    total: Fees;
+    unClaimed: Fees;
   };
 }
 
@@ -168,6 +167,7 @@ export type PoolInformation = {
   tokenAAmount: BN;
   tokenBAmount: BN;
   virtualPrice: number;
+  virtualPriceRaw: BN;
 };
 
 export type AccountsInfo = {

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -42,8 +42,6 @@ export interface LockEscrow {
   address: PublicKey;
   amount: BN;
   fee: {
-    tokenAMint: PublicKey;
-    tokenBMint: PublicKey;
     claimed: Fees;
     unClaimed: Fees;
   };

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -9,6 +9,7 @@ import { publicKey, struct, u64, u8, option } from '@project-serum/borsh';
 
 export type AmmProgram = Program<AmmIdl>;
 export type VaultProgram = Program<VaultIdl>;
+export type LockEscrowProgram = IdlAccounts<AmmIdl>['lockEscrow'];
 
 export interface AmmImplementation {
   tokenA: TokenInfo;

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -9,7 +9,6 @@ import { publicKey, struct, u64, u8, option } from '@project-serum/borsh';
 
 export type AmmProgram = Program<AmmIdl>;
 export type VaultProgram = Program<VaultIdl>;
-export type LockEscrowProgram = IdlAccounts<AmmIdl>['lockEscrow'];
 
 export interface AmmImplementation {
   tokenA: TokenInfo;
@@ -35,6 +34,7 @@ export interface AmmImplementation {
 }
 
 type Fees = {
+  lp?: BN;
   tokenA: BN;
   tokenB: BN;
 };
@@ -161,6 +161,7 @@ export type PoolState = Omit<IdlAccounts<AmmIdl>['pool'], 'curveType' | 'fees' |
 };
 export type Depeg = Omit<IdlTypes<AmmIdl>['Depeg'], 'depegType'> & { depegType: DepegType };
 export type PoolFees = IdlTypes<AmmIdl>['PoolFees'];
+export type LockEscrowAccount = IdlAccounts<AmmIdl>['lockEscrow'];
 
 export type PoolInformation = {
   tokenAAmount: BN;

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -30,6 +30,24 @@ export interface AmmImplementation {
     tokenAOutAmount: BN,
     tokenBOutAmount: BN,
   ) => Promise<Transaction>;
+  getUserLockEscrow: (owner: PublicKey) => Promise<LockEscrow | null>;
+}
+
+type Fees = {
+  tokenAFee: BN;
+  tokenBFee: BN;
+};
+
+export interface LockEscrow {
+  address: PublicKey;
+  amount: BN;
+  tokenAMint: PublicKey;
+  tokenBMint: PublicKey;
+  fee: {
+    claimed: Fees;
+    toBeClaim: Fees;
+    total: Fees;
+  };
 }
 
 export type SwapQuote = {

--- a/ts-client/src/amm/utils.ts
+++ b/ts-client/src/amm/utils.ts
@@ -37,6 +37,7 @@ import {
   STABLE_SWAP_DEFAULT_TRADE_FEE_BPS,
   CONSTANT_PRODUCT_DEFAULT_TRADE_FEE_BPS,
   METAPLEX_PROGRAM,
+  SEEDS,
 } from './constants';
 import { ConstantProductSwap, StableSwap, SwapCurve, TradeDirection } from './curve';
 import {
@@ -125,7 +126,10 @@ export const getOrCreateATAInstruction = async (
 };
 
 export const deriveLockEscrowPda = (pool: PublicKey, owner: PublicKey, ammProgram: PublicKey) => {
-  return PublicKey.findProgramAddressSync([Buffer.from('lock_escrow'), pool.toBuffer(), owner.toBuffer()], ammProgram);
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(SEEDS.LOCK_ESCROW), pool.toBuffer(), owner.toBuffer()],
+    ammProgram,
+  );
 };
 
 export const wrapSOLInstruction = (from: PublicKey, to: PublicKey, amount: bigint): TransactionInstruction[] => {

--- a/ts-client/src/amm/utils.ts
+++ b/ts-client/src/amm/utils.ts
@@ -99,6 +99,7 @@ export const getOrCreateATAInstruction = async (
   tokenMint: PublicKey,
   owner: PublicKey,
   connection: Connection,
+  payer?: PublicKey,
 ): Promise<[PublicKey, TransactionInstruction?]> => {
   let toAccount;
   try {
@@ -111,7 +112,7 @@ export const getOrCreateATAInstruction = async (
         tokenMint,
         toAccount,
         owner,
-        owner,
+        payer || owner,
       );
       return [toAccount, ix];
     }

--- a/ts-client/src/amm/utils.ts
+++ b/ts-client/src/amm/utils.ts
@@ -123,6 +123,10 @@ export const getOrCreateATAInstruction = async (
   }
 };
 
+export const deriveLockEscrowPda = (pool: PublicKey, owner: PublicKey, ammProgram: PublicKey) => {
+  return PublicKey.findProgramAddressSync([Buffer.from('lock_escrow'), pool.toBuffer(), owner.toBuffer()], ammProgram);
+};
+
 export const wrapSOLInstruction = (from: PublicKey, to: PublicKey, amount: bigint): TransactionInstruction[] => {
   return [
     SystemProgram.transfer({


### PR DESCRIPTION
Introduced a new lock escrow mechanism supported by the program.

Features:
- `AmmImpl.getLockedAtaAmount` to retrieve locked LP amounts from the ATA mechanism (old mechanism).
- `AmmImpl.getLockedLpAmount` to fetch locked LP amounts from two versions of locking: ATA (old) and escrow (new), and then sum them.
- `AmmImpl.getUserLockEscrow` to obtain the user's lock escrow state.
- `AmmImpl.lockLiquidity` to lock the user's LP into the lock escrow.
- `AmmImpl.claimLockFee` to claim fees from locked LPs in the lock escrow.
