### PR TITLE
 refactor AmmImpl.create() to use only 2 arguments: provider, poolAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor `AmmImpl.create` function to use only 2 arguments: provider, poolAddress
 - Add 2 examples for ts-client: swap, get_pool_info
-- Update @mercurial-finance/vault-sdk to version 1.0.0
+- Update @mercurial-finance/vault-sdk to version 2.0.0
 - Use tokenMint instead of tokenInfo in most cases
 - Provide address and decimals in tokenA and tokenB functions
+- Differentiate tokenMint and tokenAddress(PublickKey Only)
 
 
 ## @mercurial-finance/dynamic-amm-sdk [0.4.26] - PR #139

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use `getPoolConfigsWithPoolCreatorAuthority` to retrieve the pool configuration for a specific user. When the pool configuration returned from `getPoolConfigsWithPoolCreatorAuthority` is passed into `createPermissionlessConstantProductPoolWithConfig`, only that user can create pools. Please contact meteora team if you're not whitelisted for the config.
 
+### Changed
+
+- Refactor `AmmImpl.create` function to use only 2 arguments: provider, poolAddress
+- Add 2 examples for ts-client: swap, get_pool_info
+- Update @mercurial-finance/vault-sdk to version 1.0.0
+- Use tokenMint instead of tokenInfo in most cases
+- Provide address and decimals in tokenA and tokenB functions
+
+
 ## @mercurial-finance/dynamic-amm-sdk [0.4.26] - PR #139
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @mercurial-finance/dynamic-amm-sdk [1.0.0] - PR [#148](https://github.com/mercurial-finance/mercurial-dynamic-amm-sdk/pull/148)
+
+### Changed
+
+- Refactor `AmmImpl.create` function to use only 2 arguments: provider, poolAddress
+- Add 2 examples for ts-client: swap, get_pool_info
+- Update @mercurial-finance/vault-sdk to version 2.0.0
+- Use tokenMint instead of tokenInfo in most cases
+- Provide address and decimals in tokenAMint and tokenBMint
+- Differentiate tokenMint and tokenAddress(PublickKey Only)
+
 ## @mercurial-finance/dynamic-amm-sdk [0.5.0] - PR [#144](https://github.com/mercurial-finance/mercurial-dynamic-amm-sdk/pull/144)
 
 ### Changed
@@ -53,16 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Use `getPoolConfigsWithPoolCreatorAuthority` to retrieve the pool configuration for a specific user. When the pool configuration returned from `getPoolConfigsWithPoolCreatorAuthority` is passed into `createPermissionlessConstantProductPoolWithConfig`, only that user can create pools. Please contact meteora team if you're not whitelisted for the config.
-
-### Changed
-
-- Refactor `AmmImpl.create` function to use only 2 arguments: provider, poolAddress
-- Add 2 examples for ts-client: swap, get_pool_info
-- Update @mercurial-finance/vault-sdk to version 2.0.0
-- Use tokenMint instead of tokenInfo in most cases
-- Provide address and decimals in tokenA and tokenB functions
-- Differentiate tokenMint and tokenAddress(PublickKey Only)
-
 
 ## @mercurial-finance/dynamic-amm-sdk [0.4.26] - PR #139
 

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -15,7 +15,7 @@
     "@coral-xyz/anchor": "^0.28.0",
     "@coral-xyz/borsh": "^0.28.0",
     "@mercurial-finance/token-math": "6.0.0",
-    "@mercurial-finance/vault-sdk": "^2.0.0-rc.0",
+    "@mercurial-finance/vault-sdk": "^2.0.0",
     "@project-serum/anchor": "^0.24.2",
     "@solana/buffer-layout": "^3 || ^4",
     "@solana/spl-token": "^0.4.6",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -12,6 +12,7 @@
     "dist"
   ],
   "dependencies": {
+<<<<<<< HEAD
     "@coral-xyz/anchor": "^0.28.0",
     "@coral-xyz/borsh": "^0.28.0",
     "@mercurial-finance/token-math": "6.0.0",
@@ -21,6 +22,18 @@
     "@solana/spl-token": "^0.4.6",
     "@solana/spl-token-registry": "^0.2.4574",
     "@solana/web3.js": "^1.91.6",
+=======
+    "@mercurial-finance/vault-sdk": "^1.0.0",
+    "@project-serum/anchor": "0.24.2",
+    "@project-serum/borsh": "^0.2.5",
+    "@saberhq/anchor-contrib": "1.13.32",
+    "@saberhq/stableswap-sdk": "1.13.32",
+    "@saberhq/token-utils": "1.13.32",
+    "@solana/buffer-layout": "^3 || ^4",
+    "@solana/spl-token": "0.1.8",
+    "@solana/spl-token-registry": "0.2.1105",
+    "@solana/web3.js": "^1.42.0",
+>>>>>>> c8d23fa (update @mercurial-finance/vault-sdk to newest version 1.0.0)
     "bn-sqrt": "^1.0.0",
     "bn.js": "5.2.1",
     "decimal.js": "^10.4.1",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -12,7 +12,6 @@
     "dist"
   ],
   "dependencies": {
-<<<<<<< HEAD
     "@coral-xyz/anchor": "^0.28.0",
     "@coral-xyz/borsh": "^0.28.0",
     "@mercurial-finance/token-math": "6.0.0",
@@ -22,18 +21,6 @@
     "@solana/spl-token": "^0.4.6",
     "@solana/spl-token-registry": "^0.2.4574",
     "@solana/web3.js": "^1.91.6",
-=======
-    "@mercurial-finance/vault-sdk": "^1.0.0",
-    "@project-serum/anchor": "0.24.2",
-    "@project-serum/borsh": "^0.2.5",
-    "@saberhq/anchor-contrib": "1.13.32",
-    "@saberhq/stableswap-sdk": "1.13.32",
-    "@saberhq/token-utils": "1.13.32",
-    "@solana/buffer-layout": "^3 || ^4",
-    "@solana/spl-token": "0.1.8",
-    "@solana/spl-token-registry": "0.2.1105",
-    "@solana/web3.js": "^1.42.0",
->>>>>>> c8d23fa (update @mercurial-finance/vault-sdk to newest version 1.0.0)
     "bn-sqrt": "^1.0.0",
     "bn.js": "5.2.1",
     "decimal.js": "^10.4.1",
@@ -56,6 +43,9 @@
   },
   "peerDependencies": {
     "@solana/buffer-layout": "^3 || ^4"
+  },
+  "resulutions": {
+    "@solana/buffer-layout": "^4"
   },
   "directories": {
     "test": "tests"

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurial-finance/dynamic-amm-sdk",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "Mercurial Vaults SDK is a typescript library that allows you to interact with Mercurial v2's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@solana/buffer-layout": "^3 || ^4"
   },
-  "resulutions": {
+  "resolutions": {
     "@solana/buffer-layout": "^4"
   },
   "directories": {

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -567,19 +567,19 @@ export default class AmmImpl implements AmmImplementation {
     );
 
     const PdaInfos = poolList.reduce<
-      Array<{ tokenMint: PublicKey; vaultPda: PublicKey; tokenVaultPda: PublicKey; lpMintPda: PublicKey }>
+      Array<{ tokenAddress: PublicKey; vaultPda: PublicKey; tokenVaultPda: PublicKey; lpMintPda: PublicKey }>
     >((accList, { tokenInfoA, tokenInfoB }, index) => {
       const poolState = poolsState[index];
       return [
         ...accList,
         {
-          tokenMint: new PublicKey(tokenInfoA.address),
+          tokenAddress: new PublicKey(tokenInfoA.address),
           vaultPda: poolState.aVault,
           tokenVaultPda: poolState.aVaultLp,
           lpMintPda: poolState.lpMint,
         },
         {
-          tokenMint: new PublicKey(tokenInfoB.address),
+          tokenAddress: new PublicKey(tokenInfoB.address),
           vaultPda: poolState.bVault,
           tokenVaultPda: poolState.bVaultLp,
           lpMintPda: poolState.lpMint,
@@ -710,7 +710,7 @@ export default class AmmImpl implements AmmImplementation {
           pool,
           ammProgram,
           vaultProgram,
-          [vaultA.tokenMint, vaultB.tokenMint],
+          [new PublicKey(vaultA.tokenMint), new PublicKey(vaultB.tokenMint)],
           [tokenADecimals, tokenBDecimals],
           poolState,
           poolInfo,

--- a/ts-client/src/amm/index.ts
+++ b/ts-client/src/amm/index.ts
@@ -16,6 +16,8 @@ import { TokenInfo } from '@solana/spl-token-registry';
 import {
   AccountLayout,
   ASSOCIATED_TOKEN_PROGRAM_ID,
+  getMint,
+  Mint,
   MintLayout,
   NATIVE_MINT,
   TOKEN_PROGRAM_ID,
@@ -155,8 +157,8 @@ export default class AmmImpl implements AmmImplementation {
     public address: PublicKey,
     private program: AmmProgram,
     private vaultProgram: VaultProgram,
-    private tokenInfos: Array<PublicKey>,
-    private tokenDecimals: Array<number>,
+    public tokenAMint: Mint,
+    public tokenBMint: Mint,
     public poolState: PoolState & { lpSupply: BN },
     public poolInfo: PoolInformation,
     public vaultA: VaultImpl,
@@ -222,8 +224,8 @@ export default class AmmImpl implements AmmImplementation {
   public static async createPermissionlessConstantProductPoolWithConfig(
     connection: Connection,
     payer: PublicKey,
-    tokenInfoA: TokenInfo,
-    tokenInfoB: TokenInfo,
+    tokenAMint: PublicKey,
+    tokenBMint: PublicKey,
     tokenAAmount: BN,
     tokenBAmount: BN,
     config: PublicKey,
@@ -234,9 +236,6 @@ export default class AmmImpl implements AmmImplementation {
     },
   ) {
     const { vaultProgram, ammProgram } = createProgram(connection, opt?.programId);
-
-    let tokenAMint = new PublicKey(tokenInfoA.address);
-    let tokenBMint = new PublicKey(tokenInfoB.address);
 
     const [
       { vaultPda: aVault, tokenVaultPda: aTokenVault, lpMintPda: aLpMintPda },
@@ -253,13 +252,13 @@ export default class AmmImpl implements AmmImplementation {
     let preInstructions: Array<TransactionInstruction> = [];
 
     if (!aVaultAccount) {
-      const createVaultAIx = await VaultImpl.createPermissionlessVaultInstruction(connection, payer, new PublicKey(tokenInfoA.address));
+      const createVaultAIx = await VaultImpl.createPermissionlessVaultInstruction(connection, payer, tokenAMint);
       createVaultAIx && preInstructions.push(createVaultAIx);
     } else {
       aVaultLpMint = aVaultAccount.lpMint; // Old vault doesn't have lp mint pda
     }
     if (!bVaultAccount) {
-      const createVaultBIx = await VaultImpl.createPermissionlessVaultInstruction(connection, payer, new PublicKey(tokenInfoB.address));
+      const createVaultBIx = await VaultImpl.createPermissionlessVaultInstruction(connection, payer, tokenBMint);
       createVaultBIx && preInstructions.push(createVaultBIx);
     } else {
       bVaultLpMint = bVaultAccount.lpMint; // Old vault doesn't have lp mint pda
@@ -441,13 +440,21 @@ export default class AmmImpl implements AmmImplementation {
     preInstructions.push(setComputeUnitLimitIx);
 
     if (!aVaultAccount) {
-      const createVaultAIx = await VaultImpl.createPermissionlessVaultInstruction(connection, payer, new PublicKey(tokenInfoA.address));
+      const createVaultAIx = await VaultImpl.createPermissionlessVaultInstruction(
+        connection,
+        payer,
+        new PublicKey(tokenInfoA.address),
+      );
       createVaultAIx && preInstructions.push(createVaultAIx);
     } else {
       aVaultLpMint = aVaultAccount.lpMint; // Old vault doesn't have lp mint pda
     }
     if (!bVaultAccount) {
-      const createVaultBIx = await VaultImpl.createPermissionlessVaultInstruction(connection, payer, new PublicKey(tokenInfoB.address));
+      const createVaultBIx = await VaultImpl.createPermissionlessVaultInstruction(
+        connection,
+        payer,
+        new PublicKey(tokenInfoB.address),
+      );
       createVaultBIx && preInstructions.push(createVaultBIx);
     } else {
       bVaultLpMint = bVaultAccount.lpMint; // Old vault doesn't have lp mint pda
@@ -541,7 +548,7 @@ export default class AmmImpl implements AmmImplementation {
 
   public static async createMultiple(
     connection: Connection,
-    poolList: Array<{ pool: PublicKey; tokenInfoA: TokenInfo; tokenInfoB: TokenInfo }>,
+    poolList: Array<PublicKey>,
     opt?: {
       cluster?: Cluster;
       programId?: string;
@@ -556,30 +563,28 @@ export default class AmmImpl implements AmmImplementation {
         poolState: PoolState & { lpSupply: BN };
         vaultA: VaultImpl;
         vaultB: VaultImpl;
-        tokenInfoA: TokenInfo,
-        tokenInfoB: TokenInfo,
+        tokenAMint: Mint;
+        tokenBMint: Mint;
       }
     >();
 
-    const poolsState: Array<PoolState & { lpSupply: BN }> = await getAllPoolState(
-      poolList.map(({ pool }) => pool),
-      ammProgram,
-    );
+    const poolsState: Array<PoolState & { lpSupply: BN }> = await getAllPoolState(poolList, ammProgram);
 
     const PdaInfos = poolList.reduce<
       Array<{ tokenAddress: PublicKey; vaultPda: PublicKey; tokenVaultPda: PublicKey; lpMintPda: PublicKey }>
-    >((accList, { tokenInfoA, tokenInfoB }, index) => {
+    >((accList, _, index) => {
       const poolState = poolsState[index];
+
       return [
         ...accList,
         {
-          tokenAddress: new PublicKey(tokenInfoA.address),
+          tokenAddress: poolState.tokenAMint,
           vaultPda: poolState.aVault,
           tokenVaultPda: poolState.aVaultLp,
           lpMintPda: poolState.lpMint,
         },
         {
-          tokenAddress: new PublicKey(tokenInfoB.address),
+          tokenAddress: poolState.tokenBMint,
           vaultPda: poolState.bVault,
           tokenVaultPda: poolState.bVaultLp,
           lpMintPda: poolState.lpMint,
@@ -590,12 +595,15 @@ export default class AmmImpl implements AmmImplementation {
 
     const accountsToFetch = await Promise.all(
       poolsState.map(async (poolState, index) => {
-        const { pool, tokenInfoA, tokenInfoB } = poolList[index];
+        const pool = poolList[index];
+        const { tokenAMint: tokenAAddress, tokenBMint: tokenBAddress } = poolState;
+        const [tokenAMint, tokenBMint] = await Promise.all([
+          getMint(provider.connection, tokenAAddress),
+          getMint(provider.connection, tokenBAddress),
+        ]);
 
-        invariant(tokenInfoA.address === poolState.tokenAMint.toBase58(), `TokenInfoA provided is incorrect`);
-        invariant(tokenInfoB.address === poolState.tokenBMint.toBase58(), `TokenInfoB provided is incorrect`);
-        invariant(tokenInfoA, `TokenInfo ${poolState.tokenAMint.toBase58()} not found`);
-        invariant(tokenInfoB, `TokenInfo ${poolState.tokenBMint.toBase58()} not found`);
+        invariant(tokenAMint.address.equals(poolState.tokenAMint), `TokenInfoA provided is incorrect`);
+        invariant(tokenBMint.address.equals(poolState.tokenBMint), `TokenInfoB provided is incorrect`);
 
         const vaultA = vaultsImpl.find(({ vaultPda }) => vaultPda.equals(poolState.aVault));
         const vaultB = vaultsImpl.find(({ vaultPda }) => vaultPda.equals(poolState.bVault));
@@ -608,8 +616,8 @@ export default class AmmImpl implements AmmImplementation {
           poolState,
           vaultA,
           vaultB,
-          tokenInfoA,
-          tokenInfoB,
+          tokenAMint,
+          tokenBMint,
         });
         return [
           { pubkey: vaultA.vaultState.tokenVault, type: AccountType.VAULT_A_RESERVE },
@@ -645,13 +653,13 @@ export default class AmmImpl implements AmmImplementation {
 
         invariant(
           !!currentTime &&
-          !!vaultALpSupply &&
-          !!vaultBLpSupply &&
-          !!vaultAReserve &&
-          !!vaultBReserve &&
-          !!poolVaultALp &&
-          !!poolVaultBLp &&
-          !!poolLpSupply,
+            !!vaultALpSupply &&
+            !!vaultBLpSupply &&
+            !!vaultAReserve &&
+            !!vaultBReserve &&
+            !!poolVaultALp &&
+            !!poolVaultBLp &&
+            !!poolLpSupply,
           'Account Info not found',
         );
 
@@ -670,14 +678,14 @@ export default class AmmImpl implements AmmImplementation {
 
         invariant(poolInfoData, 'Cannot find pool info');
 
-        const { pool, poolState, vaultA, vaultB, tokenInfoA, tokenInfoB } = poolInfoData;
+        const { pool, poolState, vaultA, vaultB, tokenAMint, tokenBMint } = poolInfoData;
 
         const [tokenASupply, tokenBSupply] = await Promise.all([
           provider.connection.getTokenSupply(poolState.tokenAMint),
-          provider.connection.getTokenSupply(poolState.tokenBMint)
-        ])
-        const tokenADecimals = tokenASupply.value.decimals
-        const tokenBDecimals = tokenBSupply.value.decimals
+          provider.connection.getTokenSupply(poolState.tokenBMint),
+        ]);
+        const tokenADecimals = tokenASupply.value.decimals;
+        const tokenBDecimals = tokenBSupply.value.decimals;
 
         let swapCurve;
         if ('stable' in poolState.curveType) {
@@ -710,8 +718,8 @@ export default class AmmImpl implements AmmImplementation {
           pool,
           ammProgram,
           vaultProgram,
-          [new PublicKey(vaultA.tokenMint), new PublicKey(vaultB.tokenMint)],
-          [tokenADecimals, tokenBDecimals],
+          tokenAMint,
+          tokenBMint,
           poolState,
           poolInfo,
           vaultA,
@@ -835,17 +843,15 @@ export default class AmmImpl implements AmmImplementation {
     const { provider, vaultProgram, ammProgram } = createProgram(connection, opt?.programId);
 
     const poolState = await getPoolState(pool, ammProgram);
-    const { tokenAMint, tokenBMint } = poolState
-    const [tokenASupply, tokenBSupply] = await Promise.all([
-      provider.connection.getTokenSupply(tokenAMint),
-      provider.connection.getTokenSupply(tokenBMint)
-    ])
-    const tokenADecimals = tokenASupply.value.decimals
-    const tokenBDecimals = tokenBSupply.value.decimals
+    const { tokenAMint: tokenAAddress, tokenBMint: tokenBAddress } = poolState;
+    const [tokenAMint, tokenBMint] = await Promise.all([
+      getMint(provider.connection, tokenAAddress),
+      getMint(provider.connection, tokenBAddress),
+    ]);
 
     const [vaultA, vaultB] = await Promise.all([
-      VaultImpl.create(provider.connection, tokenAMint, { cluster, seedBaseKey: opt?.vaultSeedBaseKey }),
-      VaultImpl.create(provider.connection, tokenBMint, { cluster, seedBaseKey: opt?.vaultSeedBaseKey }),
+      VaultImpl.create(provider.connection, tokenAAddress, { cluster, seedBaseKey: opt?.vaultSeedBaseKey }),
+      VaultImpl.create(provider.connection, tokenBAddress, { cluster, seedBaseKey: opt?.vaultSeedBaseKey }),
     ]);
 
     const accountsBufferMap = await getAccountsBuffer(connection, [
@@ -871,13 +877,13 @@ export default class AmmImpl implements AmmImplementation {
 
     invariant(
       !!currentTime &&
-      !!vaultALpSupply &&
-      !!vaultBLpSupply &&
-      !!vaultAReserve &&
-      !!vaultBReserve &&
-      !!poolVaultALp &&
-      !!poolVaultBLp &&
-      !!poolLpSupply,
+        !!vaultALpSupply &&
+        !!vaultBLpSupply &&
+        !!vaultAReserve &&
+        !!vaultBReserve &&
+        !!poolVaultALp &&
+        !!poolVaultBLp &&
+        !!poolLpSupply,
       'Account Info not found',
     );
 
@@ -918,8 +924,8 @@ export default class AmmImpl implements AmmImplementation {
       pool,
       ammProgram,
       vaultProgram,
-      [tokenAMint, tokenBMint],
-      [tokenADecimals, tokenBDecimals],
+      tokenAMint,
+      tokenBMint,
       poolState,
       poolInfo,
       vaultA,
@@ -933,16 +939,8 @@ export default class AmmImpl implements AmmImplementation {
     );
   }
 
-  get tokenA(): tokenAddressAndDecimals {
-    return { address: this.tokenInfos[0].toString(), decimals: this.tokenDecimals[0] };
-  }
-
-  get tokenB(): tokenAddressAndDecimals {
-    return { address: this.tokenInfos[1].toString(), decimals: this.tokenDecimals[1] };
-  }
-
   get decimals(): number {
-    return Math.max(this.tokenA.decimals, this.tokenB.decimals);
+    return Math.max(this.tokenAMint.decimals, this.tokenBMint.decimals);
   }
 
   get isStablePool(): boolean {
@@ -959,7 +957,7 @@ export default class AmmImpl implements AmmImplementation {
     return this.poolState.fees.tradeFeeNumerator.mul(new BN(10000)).div(this.poolState.fees.tradeFeeDenominator);
   }
 
-  get depegToken(): tokenAddressAndDecimals | null {
+  get depegToken(): Mint | null {
     if (!this.isStablePool) return null;
     const { tokenMultiplier } = this.poolState.curveType['stable'] as any;
     const tokenABalance = this.poolInfo.tokenAAmount.mul(tokenMultiplier.tokenAMultiplier);
@@ -979,8 +977,8 @@ export default class AmmImpl implements AmmImplementation {
       .mul(new BN(100))
       .gt(new BN(95));
 
-    if (isTokenADepeg) return this.tokenA;
-    if (isTokenBDepeg) return this.tokenB;
+    if (isTokenADepeg) return this.tokenAMint;
+    if (isTokenBDepeg) return this.tokenBMint;
     return null;
   }
 
@@ -1032,13 +1030,13 @@ export default class AmmImpl implements AmmImplementation {
 
     invariant(
       !!currentTime &&
-      !!vaultALpSupply &&
-      !!vaultBLpSupply &&
-      !!vaultAReserve &&
-      !!vaultBReserve &&
-      !!poolVaultALp &&
-      !!poolVaultBLp &&
-      !!poolLpSupply,
+        !!vaultALpSupply &&
+        !!vaultBLpSupply &&
+        !!vaultAReserve &&
+        !!vaultBReserve &&
+        !!poolVaultALp &&
+        !!poolVaultBLp &&
+        !!poolLpSupply,
       'Account Info not found',
     );
 
@@ -1213,15 +1211,13 @@ export default class AmmImpl implements AmmImplementation {
     outAmountLamport: BN,
     referralOwner?: PublicKey,
   ): Promise<Transaction> {
-    const [sourceToken, destinationToken] =
-      this.tokenA.address === inTokenMint.toBase58()
-        ? [this.poolState.tokenAMint, this.poolState.tokenBMint]
-        : [this.poolState.tokenBMint, this.poolState.tokenAMint];
+    const [sourceToken, destinationToken] = this.tokenAMint.address.equals(inTokenMint)
+      ? [this.poolState.tokenAMint, this.poolState.tokenBMint]
+      : [this.poolState.tokenBMint, this.poolState.tokenAMint];
 
-    const protocolTokenFee =
-      this.tokenA.address === inTokenMint.toBase58()
-        ? this.poolState.protocolTokenAFee
-        : this.poolState.protocolTokenBFee;
+    const protocolTokenFee = this.tokenAMint.address.equals(inTokenMint)
+      ? this.poolState.protocolTokenAFee
+      : this.poolState.protocolTokenBFee;
 
     let preInstructions: Array<TransactionInstruction> = [];
     const [[userSourceToken, createUserSourceIx], [userDestinationToken, createUserDestinationIx]] =
@@ -1469,19 +1465,19 @@ export default class AmmImpl implements AmmImplementation {
     createTokenBIx && preInstructions.push(createTokenBIx);
     createLpMintIx && preInstructions.push(createLpMintIx);
 
-    if (NATIVE_MINT.equals(new PublicKey(this.tokenA.address))) {
+    if (NATIVE_MINT.equals(this.tokenAMint.address)) {
       preInstructions = preInstructions.concat(
         wrapSOLInstruction(owner, userAToken, BigInt(tokenAInAmount.toString())),
       );
     }
-    if (NATIVE_MINT.equals(new PublicKey(this.tokenB.address))) {
+    if (NATIVE_MINT.equals(this.tokenBMint.address)) {
       preInstructions = preInstructions.concat(
         wrapSOLInstruction(owner, userBToken, BigInt(tokenBInAmount.toString())),
       );
     }
 
     const postInstructions: Array<TransactionInstruction> = [];
-    if ([this.tokenA.address, this.tokenB.address].includes(NATIVE_MINT.toBase58())) {
+    if ([this.tokenAMint.address.toBase58(), this.tokenBMint.address.toBase58()].includes(NATIVE_MINT.toBase58())) {
       const closeWrappedSOLIx = await unwrapSOLInstruction(owner);
       closeWrappedSOLIx && postInstructions.push(closeWrappedSOLIx);
     }
@@ -1577,8 +1573,8 @@ export default class AmmImpl implements AmmImplementation {
     }
 
     // Imbalance withdraw
-    const isWithdrawingTokenA = tokenMint.equals(new PublicKey(this.tokenA.address));
-    const isWithdrawingTokenB = tokenMint.equals(new PublicKey(this.tokenB.address));
+    const isWithdrawingTokenA = tokenMint.equals(this.tokenAMint.address);
+    const isWithdrawingTokenB = tokenMint.equals(this.tokenBMint.address);
     invariant(isWithdrawingTokenA || isWithdrawingTokenB, ERROR.INVALID_MINT);
 
     const tradeDirection = tokenMint.equals(this.poolState.tokenAMint) ? TradeDirection.BToA : TradeDirection.AToB;
@@ -1639,7 +1635,7 @@ export default class AmmImpl implements AmmImplementation {
     createLpTokenIx && preInstructions.push(createLpTokenIx);
 
     const postInstructions: Array<TransactionInstruction> = [];
-    if ([this.tokenA.address, this.tokenB.address].includes(NATIVE_MINT.toBase58())) {
+    if ([this.tokenAMint.address.toBase58(), this.tokenBMint.address.toBase58()].includes(NATIVE_MINT.toBase58())) {
       const closeWrappedSOLIx = await unwrapSOLInstruction(owner);
       closeWrappedSOLIx && postInstructions.push(closeWrappedSOLIx);
     }
@@ -1647,40 +1643,40 @@ export default class AmmImpl implements AmmImplementation {
     const programMethod =
       this.isStablePool && (tokenAOutAmount.isZero() || tokenBOutAmount.isZero())
         ? this.program.methods.removeLiquiditySingleSide(lpTokenAmount, new BN(0)).accounts({
-          aTokenVault: this.vaultA.vaultState.tokenVault,
-          aVault: this.poolState.aVault,
-          aVaultLp: this.poolState.aVaultLp,
-          aVaultLpMint: this.vaultA.vaultState.lpMint,
-          bTokenVault: this.vaultB.vaultState.tokenVault,
-          bVault: this.poolState.bVault,
-          bVaultLp: this.poolState.bVaultLp,
-          bVaultLpMint: this.vaultB.vaultState.lpMint,
-          lpMint: this.poolState.lpMint,
-          pool: this.address,
-          userDestinationToken: tokenBOutAmount.isZero() ? userAToken : userBToken,
-          userPoolLp,
-          user: owner,
-          tokenProgram: TOKEN_PROGRAM_ID,
-          vaultProgram: this.vaultProgram.programId,
-        })
+            aTokenVault: this.vaultA.vaultState.tokenVault,
+            aVault: this.poolState.aVault,
+            aVaultLp: this.poolState.aVaultLp,
+            aVaultLpMint: this.vaultA.vaultState.lpMint,
+            bTokenVault: this.vaultB.vaultState.tokenVault,
+            bVault: this.poolState.bVault,
+            bVaultLp: this.poolState.bVaultLp,
+            bVaultLpMint: this.vaultB.vaultState.lpMint,
+            lpMint: this.poolState.lpMint,
+            pool: this.address,
+            userDestinationToken: tokenBOutAmount.isZero() ? userAToken : userBToken,
+            userPoolLp,
+            user: owner,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            vaultProgram: this.vaultProgram.programId,
+          })
         : this.program.methods.removeBalanceLiquidity(lpTokenAmount, tokenAOutAmount, tokenBOutAmount).accounts({
-          pool: this.address,
-          lpMint: this.poolState.lpMint,
-          aVault: this.poolState.aVault,
-          aTokenVault: this.vaultA.vaultState.tokenVault,
-          aVaultLp: this.poolState.aVaultLp,
-          aVaultLpMint: this.vaultA.vaultState.lpMint,
-          bVault: this.poolState.bVault,
-          bTokenVault: this.vaultB.vaultState.tokenVault,
-          bVaultLp: this.poolState.bVaultLp,
-          bVaultLpMint: this.vaultB.vaultState.lpMint,
-          userAToken,
-          userBToken,
-          user: owner,
-          userPoolLp,
-          tokenProgram: TOKEN_PROGRAM_ID,
-          vaultProgram: this.vaultProgram.programId,
-        });
+            pool: this.address,
+            lpMint: this.poolState.lpMint,
+            aVault: this.poolState.aVault,
+            aTokenVault: this.vaultA.vaultState.tokenVault,
+            aVaultLp: this.poolState.aVaultLp,
+            aVaultLpMint: this.vaultA.vaultState.lpMint,
+            bVault: this.poolState.bVault,
+            bTokenVault: this.vaultB.vaultState.tokenVault,
+            bVaultLp: this.poolState.bVaultLp,
+            bVaultLpMint: this.vaultB.vaultState.lpMint,
+            userAToken,
+            userBToken,
+            user: owner,
+            userPoolLp,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            vaultProgram: this.vaultProgram.programId,
+          });
 
     const withdrawTx = await programMethod
       .remainingAccounts(this.swapCurve.getRemainingAccounts())

--- a/ts-client/src/amm/tests/constantProduct.test.ts
+++ b/ts-client/src/amm/tests/constantProduct.test.ts
@@ -127,7 +127,7 @@ describe('Constant product pool', () => {
       await connection.confirmTransaction(txHash, 'finalized');
 
       const poolKey = derivePoolAddress(connection, btcTokenInfo, usdcTokenInfo, false, tradeFeeBps);
-      cpPoolFeeTiered = await AmmImpl.create(connection, poolKey, btcTokenInfo, usdcTokenInfo);
+      cpPoolFeeTiered = await AmmImpl.create(connection, poolKey);
 
       expect(poolKey.toBase58()).toBe(cpPoolFeeTiered.address.toBase58());
       expect(cpPoolFeeTiered.isStablePool).toBe(false);
@@ -345,7 +345,7 @@ describe('Constant product pool', () => {
         configs[0].publicKey,
         new PublicKey(PROGRAM_ID),
       );
-      cpPoolConfig = await AmmImpl.create(connection, poolKey, btcTokenInfo, usdcTokenInfo);
+      cpPoolConfig = await AmmImpl.create(connection, poolKey);
 
       expect(poolKey.toBase58()).toBe(cpPoolConfig.address.toBase58());
       expect(cpPoolConfig.isStablePool).toBe(false);

--- a/ts-client/src/amm/tests/constantProduct.test.ts
+++ b/ts-client/src/amm/tests/constantProduct.test.ts
@@ -1,11 +1,7 @@
 import { AnchorProvider, BN } from '@coral-xyz/anchor';
 import { TokenInfo } from '@solana/spl-token-registry';
 import { Connection, Keypair, PublicKey } from '@solana/web3.js';
-import {
-  CONSTANT_PRODUCT_DEFAULT_TRADE_FEE_BPS,
-  DEFAULT_SLIPPAGE,
-  PROGRAM_ID,
-} from '../constants';
+import { CONSTANT_PRODUCT_DEFAULT_TRADE_FEE_BPS, DEFAULT_SLIPPAGE, PROGRAM_ID } from '../constants';
 import AmmImpl from '../index';
 import { derivePoolAddress, derivePoolAddressWithConfig, getOnchainTime } from '../utils';
 import { airDropSol, getOrCreateATA, mockWallet } from './utils';
@@ -37,14 +33,7 @@ describe('Constant product pool', () => {
 
   beforeAll(async () => {
     await airDropSol(connection, mockWallet.publicKey, 10);
-    BTC = await createMint(
-      provider.connection,
-      mockWallet.payer,
-      mockWallet.publicKey,
-      null,
-      btcDecimal,
-
-    );
+    BTC = await createMint(provider.connection, mockWallet.payer, mockWallet.publicKey, null, btcDecimal);
 
     btcTokenInfo = {
       chainId: 101,
@@ -55,13 +44,7 @@ describe('Constant product pool', () => {
       logoURI: 'https://assets.coingecko.com/coins/images/1/large/bitcoin.png',
     };
 
-    USDC = await createMint(
-      provider.connection,
-      mockWallet.payer,
-      mockWallet.publicKey,
-      null,
-      usdcDecimal,
-    );
+    USDC = await createMint(provider.connection, mockWallet.payer, mockWallet.publicKey, null, usdcDecimal);
 
     usdcTokenInfo = {
       chainId: 101,
@@ -84,7 +67,7 @@ describe('Constant product pool', () => {
       10000 * btcMultiplier,
       [],
       {
-        commitment: "confirmed",
+        commitment: 'confirmed',
       },
     );
 
@@ -97,7 +80,7 @@ describe('Constant product pool', () => {
       1000000 * usdcMultiplier,
       [],
       {
-        commitment: "confirmed",
+        commitment: 'confirmed',
       },
     );
 
@@ -131,8 +114,8 @@ describe('Constant product pool', () => {
 
       expect(poolKey.toBase58()).toBe(cpPoolFeeTiered.address.toBase58());
       expect(cpPoolFeeTiered.isStablePool).toBe(false);
-      expect(cpPoolFeeTiered.tokenA.address.toString()).toBe(BTC.toString());
-      expect(cpPoolFeeTiered.tokenB.address.toString()).toBe(USDC.toString());
+      expect(cpPoolFeeTiered.tokenAMint.address.toString()).toBe(BTC.toString());
+      expect(cpPoolFeeTiered.tokenBMint.address.toString()).toBe(USDC.toString());
     });
 
     test('Get pool mint and supply', async () => {
@@ -232,8 +215,8 @@ describe('Constant product pool', () => {
 
     test('Swap A → B', async () => {
       await cpPoolFeeTiered.updateState();
-      const inAmountLamport = new BN(0.1 * 10 ** cpPoolFeeTiered.tokenA.decimals);
-      const inTokenMint = new PublicKey(cpPoolFeeTiered.tokenA.address);
+      const inAmountLamport = new BN(0.1 * 10 ** cpPoolFeeTiered.tokenAMint.decimals);
+      const inTokenMint = new PublicKey(cpPoolFeeTiered.tokenAMint.address);
 
       const { swapOutAmount, minSwapOutAmount } = cpPoolFeeTiered.getSwapQuote(
         inTokenMint,
@@ -266,8 +249,8 @@ describe('Constant product pool', () => {
 
     test('Swap B → A', async () => {
       await cpPoolFeeTiered.updateState();
-      const inAmountLamport = new BN(0.1 * 10 ** cpPoolFeeTiered.tokenB.decimals);
-      const inTokenMint = new PublicKey(cpPoolFeeTiered.tokenB.address);
+      const inAmountLamport = new BN(0.1 * 10 ** cpPoolFeeTiered.tokenBMint.decimals);
+      const inTokenMint = new PublicKey(cpPoolFeeTiered.tokenBMint.address);
 
       const { swapOutAmount, minSwapOutAmount } = cpPoolFeeTiered.getSwapQuote(
         inTokenMint,
@@ -326,8 +309,8 @@ describe('Constant product pool', () => {
       const transactions = await AmmImpl.createPermissionlessConstantProductPoolWithConfig(
         connection,
         mockWallet.publicKey,
-        btcTokenInfo,
-        usdcTokenInfo,
+        new PublicKey(btcTokenInfo.address),
+        new PublicKey(usdcTokenInfo.address),
         btcDepositAmount,
         usdcDepositAmount,
         configs[0].publicKey,
@@ -349,8 +332,8 @@ describe('Constant product pool', () => {
 
       expect(poolKey.toBase58()).toBe(cpPoolConfig.address.toBase58());
       expect(cpPoolConfig.isStablePool).toBe(false);
-      expect(cpPoolConfig.tokenA.address.toString()).toBe(BTC.toString());
-      expect(cpPoolConfig.tokenB.address.toString()).toBe(USDC.toString());
+      expect(cpPoolConfig.tokenAMint.address.toString()).toBe(BTC.toString());
+      expect(cpPoolConfig.tokenBMint.address.toString()).toBe(USDC.toString());
       const poolFees = cpPoolConfig.poolState.fees;
       expect(poolFees.tradeFeeNumerator.gt(new BN(0))).toBe(true);
       expect(poolFees.protocolTradeFeeNumerator.gt(new BN(0))).toBe(true);
@@ -453,8 +436,8 @@ describe('Constant product pool', () => {
 
     test('Swap A → B', async () => {
       await cpPoolConfig.updateState();
-      const inAmountLamport = new BN(0.1 * 10 ** cpPoolConfig.tokenA.decimals);
-      const inTokenMint = new PublicKey(cpPoolConfig.tokenA.address);
+      const inAmountLamport = new BN(0.1 * 10 ** cpPoolConfig.tokenAMint.decimals);
+      const inTokenMint = new PublicKey(cpPoolConfig.tokenAMint.address);
 
       const { swapOutAmount, minSwapOutAmount } = cpPoolConfig.getSwapQuote(
         inTokenMint,
@@ -487,8 +470,8 @@ describe('Constant product pool', () => {
 
     test('Swap B → A', async () => {
       await cpPoolConfig.updateState();
-      const inAmountLamport = new BN(0.1 * 10 ** cpPoolConfig.tokenB.decimals);
-      const inTokenMint = new PublicKey(cpPoolConfig.tokenB.address);
+      const inAmountLamport = new BN(0.1 * 10 ** cpPoolConfig.tokenBMint.decimals);
+      const inTokenMint = new PublicKey(cpPoolConfig.tokenBMint.address);
 
       const { swapOutAmount, minSwapOutAmount } = cpPoolConfig.getSwapQuote(
         inTokenMint,
@@ -521,8 +504,8 @@ describe('Constant product pool', () => {
 
     test('Swap with referral', async () => {
       await cpPoolConfig.updateState();
-      const inAmountLamport = new BN(10 * 10 ** cpPoolConfig.tokenA.decimals);
-      const inTokenMint = new PublicKey(cpPoolConfig.tokenA.address);
+      const inAmountLamport = new BN(10 * 10 ** cpPoolConfig.tokenAMint.decimals);
+      const inTokenMint = new PublicKey(cpPoolConfig.tokenAMint.address);
 
       const { swapOutAmount, minSwapOutAmount } = cpPoolConfig.getSwapQuote(
         inTokenMint,

--- a/ts-client/src/amm/tests/error.test.ts
+++ b/ts-client/src/amm/tests/error.test.ts
@@ -133,7 +133,7 @@ describe('Error parsing', () => {
     await connection.confirmTransaction(txHash, 'finalized');
 
     let poolKey = derivePoolAddress(connection, usdtTokenInfo, usdcTokenInfo, true, tradeFeeBps);
-    stablePool = await AmmImpl.create(connection, poolKey, usdtTokenInfo, usdcTokenInfo);
+    stablePool = await AmmImpl.create(connection, poolKey);
 
     tradeFeeBps = new BN(CONSTANT_PRODUCT_DEFAULT_TRADE_FEE_BPS);
     transaction = await AmmImpl.createPermissionlessPool(
@@ -152,9 +152,9 @@ describe('Error parsing', () => {
     await connection.confirmTransaction(txHash, 'finalized');
 
     poolKey = derivePoolAddress(connection, usdtTokenInfo, usdcTokenInfo, false, tradeFeeBps);
-    cpPool = await AmmImpl.create(connection, poolKey, usdtTokenInfo, usdcTokenInfo);
+    cpPool = await AmmImpl.create(connection, poolKey);
 
-    lstPool = await AmmImpl.create(connection, MAINNET_POOL.SOL_MSOL, solTokenInfo, msolTokenInfo);
+    lstPool = await AmmImpl.create(connection, MAINNET_POOL.SOL_MSOL);
   });
 
   test('Should throw slippage error', async () => {

--- a/ts-client/src/amm/tests/error.test.ts
+++ b/ts-client/src/amm/tests/error.test.ts
@@ -43,14 +43,7 @@ describe('Error parsing', () => {
   beforeAll(async () => {
     await airDropSol(connection, mockWallet.publicKey, 10);
 
-
-    USDT = await createMint(
-      provider.connection,
-      mockWallet.payer,
-      mockWallet.publicKey,
-      null,
-      usdtDecimal,
-    );
+    USDT = await createMint(provider.connection, mockWallet.payer, mockWallet.publicKey, null, usdtDecimal);
 
     usdtTokenInfo = {
       chainId: 101,
@@ -61,14 +54,7 @@ describe('Error parsing', () => {
       logoURI: 'https://assets.coingecko.com/coins/images/325/large/Tether.png',
     };
 
-
-    USDC = await createMint(
-      provider.connection,
-      mockWallet.payer,
-      mockWallet.publicKey,
-      null,
-      usdcDecimal,
-    );
+    USDC = await createMint(provider.connection, mockWallet.payer, mockWallet.publicKey, null, usdcDecimal);
 
     usdcTokenInfo = {
       chainId: 101,
@@ -82,7 +68,6 @@ describe('Error parsing', () => {
     mockWalletUsdtATA = await getOrCreateATA(connection, USDT, mockWallet.publicKey, mockWallet.payer);
     mockWalletUsdcATA = await getOrCreateATA(connection, USDC, mockWallet.publicKey, mockWallet.payer);
 
-
     await mintTo(
       provider.connection,
       mockWallet.payer,
@@ -92,7 +77,7 @@ describe('Error parsing', () => {
       1000000 * usdtMultiplier,
       [],
       {
-        commitment: "confirmed",
+        commitment: 'confirmed',
       },
     );
 
@@ -105,7 +90,7 @@ describe('Error parsing', () => {
       1000000 * usdcMultiplier,
       [],
       {
-        commitment: "confirmed",
+        commitment: 'confirmed',
       },
     );
   });
@@ -158,7 +143,7 @@ describe('Error parsing', () => {
   });
 
   test('Should throw slippage error', async () => {
-    const inAmountBLamport = new BN(0.1 * 10 ** cpPool.tokenB.decimals);
+    const inAmountBLamport = new BN(0.1 * 10 ** cpPool.tokenBMint.decimals);
 
     const { tokenAInAmount: cpTokenAInAmount, tokenBInAmount: cpTokenBInAmount } = cpPool.getDepositQuote(
       new BN(0),
@@ -180,7 +165,7 @@ describe('Error parsing', () => {
       expect(ammError.errorCode).toBe(IDL.errors[4].code);
     });
 
-    const inLamportAmount = new BN(1 * 10 ** lstPool.tokenA.decimals);
+    const inLamportAmount = new BN(1 * 10 ** lstPool.tokenAMint.decimals);
     const { tokenAInAmount: depegTokenAInAmount, tokenBInAmount: depegTokenBInAmount } = lstPool.getDepositQuote(
       inLamportAmount,
       new BN(0),

--- a/ts-client/src/amm/tests/stableSwap.test.ts
+++ b/ts-client/src/amm/tests/stableSwap.test.ts
@@ -49,14 +49,7 @@ describe('Stable Swap pool', () => {
   beforeAll(async () => {
     await airDropSol(connection, mockWallet.publicKey, 10);
 
-
-    USDT = await createMint(
-      provider.connection,
-      mockWallet.payer,
-      mockWallet.publicKey,
-      null,
-      usdtDecimal,
-    );
+    USDT = await createMint(provider.connection, mockWallet.payer, mockWallet.publicKey, null, usdtDecimal);
 
     usdtTokenInfo = {
       chainId: 101,
@@ -67,14 +60,7 @@ describe('Stable Swap pool', () => {
       logoURI: 'https://assets.coingecko.com/coins/images/325/large/Tether.png',
     };
 
-
-    USDC = await createMint(
-      provider.connection,
-      mockWallet.payer,
-      mockWallet.publicKey,
-      null,
-      usdcDecimal,
-    );
+    USDC = await createMint(provider.connection, mockWallet.payer, mockWallet.publicKey, null, usdcDecimal);
     usdcTokenInfo = {
       chainId: 101,
       address: USDC.toString(),
@@ -87,7 +73,6 @@ describe('Stable Swap pool', () => {
     mockWalletUsdtATA = await getOrCreateATA(connection, USDT, mockWallet.publicKey, mockWallet.payer);
     mockWalletUsdcATA = await getOrCreateATA(connection, USDC, mockWallet.publicKey, mockWallet.payer);
 
-
     await mintTo(
       provider.connection,
       mockWallet.payer,
@@ -97,7 +82,7 @@ describe('Stable Swap pool', () => {
       1000000 * usdtMultiplier,
       [],
       {
-        commitment: "confirmed",
+        commitment: 'confirmed',
       },
     );
 
@@ -110,7 +95,7 @@ describe('Stable Swap pool', () => {
       1000000 * usdcMultiplier,
       [],
       {
-        commitment: "confirmed",
+        commitment: 'confirmed',
       },
     );
   });
@@ -141,8 +126,8 @@ describe('Stable Swap pool', () => {
 
       expect(poolKey.toBase58()).toBe(stableSwapFeeTiered.address.toBase58());
       expect(stableSwapFeeTiered.isStablePool).toBe(true);
-      expect(stableSwapFeeTiered.tokenA.address.toString()).toBe(USDT.toString());
-      expect(stableSwapFeeTiered.tokenB.address.toString()).toBe(USDC.toString());
+      expect(stableSwapFeeTiered.tokenAMint.address.toString()).toBe(USDT.toString());
+      expect(stableSwapFeeTiered.tokenBMint.address.toString()).toBe(USDC.toString());
     });
 
     test('Get pool mint and supply', async () => {
@@ -323,8 +308,8 @@ describe('Stable Swap pool', () => {
 
     test('Swap A → B', async () => {
       await stableSwapFeeTiered.updateState();
-      const inAmountLamport = new BN(0.1 * 10 ** stableSwapFeeTiered.tokenA.decimals);
-      const inTokenMint = new PublicKey(stableSwapFeeTiered.tokenA.address);
+      const inAmountLamport = new BN(0.1 * 10 ** stableSwapFeeTiered.tokenAMint.decimals);
+      const inTokenMint = new PublicKey(stableSwapFeeTiered.tokenAMint.address);
 
       const { swapOutAmount, minSwapOutAmount } = stableSwapFeeTiered.getSwapQuote(
         inTokenMint,
@@ -362,8 +347,8 @@ describe('Stable Swap pool', () => {
 
     test('Swap B → A', async () => {
       await stableSwapFeeTiered.updateState();
-      const inAmountLamport = new BN(0.1 * 10 ** stableSwapFeeTiered.tokenB.decimals);
-      const inTokenMint = new PublicKey(stableSwapFeeTiered.tokenB.address);
+      const inAmountLamport = new BN(0.1 * 10 ** stableSwapFeeTiered.tokenBMint.decimals);
+      const inTokenMint = new PublicKey(stableSwapFeeTiered.tokenBMint.address);
 
       const { swapOutAmount, minSwapOutAmount } = stableSwapFeeTiered.getSwapQuote(
         inTokenMint,

--- a/ts-client/src/amm/tests/stableSwap.test.ts
+++ b/ts-client/src/amm/tests/stableSwap.test.ts
@@ -137,7 +137,7 @@ describe('Stable Swap pool', () => {
       await connection.confirmTransaction(txHash, 'finalized');
 
       const poolKey = derivePoolAddress(connection, usdtTokenInfo, usdcTokenInfo, true, tradeFeeBps);
-      stableSwapFeeTiered = await AmmImpl.create(connection, poolKey, usdtTokenInfo, usdcTokenInfo);
+      stableSwapFeeTiered = await AmmImpl.create(connection, poolKey);
 
       expect(poolKey.toBase58()).toBe(stableSwapFeeTiered.address.toBase58());
       expect(stableSwapFeeTiered.isStablePool).toBe(true);
@@ -416,7 +416,7 @@ describe('LST pool', () => {
       mockWallet.payer,
     );
 
-    lstPool = await AmmImpl.create(connection, MAINNET_POOL.SOL_MSOL, solTokenInfo, msolTokenInfo);
+    lstPool = await AmmImpl.create(connection, MAINNET_POOL.SOL_MSOL);
   });
 
   test('Is LST', () => {

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -11,8 +11,6 @@ export type AmmProgram = Program<AmmIdl>;
 export type VaultProgram = Program<VaultIdl>;
 
 export interface AmmImplementation {
-  tokenA: tokenAddressAndDecimals;
-  tokenB: tokenAddressAndDecimals;
   decimals: number;
   isStablePool: boolean;
   updateState: () => Promise<void>;
@@ -40,8 +38,8 @@ type Fees = {
 };
 
 export type tokenAddressAndDecimals = {
-  address: string,
-  decimals: number
+  address: string;
+  decimals: number;
 };
 
 export interface LockEscrow {
@@ -118,7 +116,7 @@ export type StableSwapCurve = {
     amp: BN;
     tokenMultiplier: TokenMultiplier;
     depeg: Depeg;
-    lastAmpUpdatedTimestamp: BN,
+    lastAmpUpdatedTimestamp: BN;
   };
 };
 

--- a/ts-client/src/amm/types/index.ts
+++ b/ts-client/src/amm/types/index.ts
@@ -11,8 +11,8 @@ export type AmmProgram = Program<AmmIdl>;
 export type VaultProgram = Program<VaultIdl>;
 
 export interface AmmImplementation {
-  tokenA: TokenInfo;
-  tokenB: TokenInfo;
+  tokenA: tokenAddressAndDecimals;
+  tokenB: tokenAddressAndDecimals;
   decimals: number;
   isStablePool: boolean;
   updateState: () => Promise<void>;
@@ -37,6 +37,11 @@ type Fees = {
   lp?: BN;
   tokenA: BN;
   tokenB: BN;
+};
+
+export type tokenAddressAndDecimals = {
+  address: string,
+  decimals: number
 };
 
 export interface LockEscrow {

--- a/ts-client/src/examples/create_pool_with_authorized_config.ts
+++ b/ts-client/src/examples/create_pool_with_authorized_config.ts
@@ -1,5 +1,4 @@
 import { Wallet } from '@coral-xyz/anchor';
-import { TokenInfo } from '@solana/spl-token-registry';
 import { Connection, Keypair, PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
 import fs from 'fs';
@@ -17,8 +16,8 @@ const payerWallet = new Wallet(payerKP);
 console.log('payer %s', payerKP.publicKey);
 
 async function createPool(
-  tokenAInfo: TokenInfo,
-  tokenBInfo: TokenInfo,
+  tokenAMint: PublicKey,
+  tokenBMint: PublicKey,
   tokenAAmount: BN,
   tokenBAmount: BN,
   config: PublicKey,
@@ -27,8 +26,8 @@ async function createPool(
   const transactions = await AmmImpl.createPermissionlessConstantProductPoolWithConfig(
     connection,
     payer.publicKey,
-    tokenAInfo,
-    tokenBInfo,
+    tokenAMint,
+    tokenBMint,
     tokenAAmount,
     tokenBAmount,
     config,
@@ -43,22 +42,8 @@ async function createPool(
 }
 
 async function main() {
-  let tokenAInfo = {
-    chainId: 101,
-    address: 'BjhBG7jkHYMBMos2HtRdFrw8rvSguBe5c3a3EJYXhyUf',
-    symbol: 'TA',
-    decimals: 6,
-    name: 'TokenATest',
-    logoURI: '',
-  };
-  let tokenBInfo = {
-    chainId: 101,
-    address: '9KMeJp868Pdk8PrJEkwoAHMA1ctdxfVhe2TjeS4BcWjs',
-    symbol: 'TB',
-    decimals: 6,
-    name: 'TokenBTest',
-    logoURI: '',
-  };
+  const tokenAMint = new PublicKey('BjhBG7jkHYMBMos2HtRdFrw8rvSguBe5c3a3EJYXhyUf');
+  const tokenBMint = new PublicKey('9KMeJp868Pdk8PrJEkwoAHMA1ctdxfVhe2TjeS4BcWjs');
 
   // Retrieve config accounts where authorized pool creator key is the payerKP
   const configs = await AmmImpl.getPoolConfigsWithPoolCreatorAuthority(connection, payerWallet.publicKey);
@@ -72,8 +57,8 @@ async function main() {
 
   // Create pool
   await createPool(
-    tokenAInfo,
-    tokenBInfo,
+    tokenAMint,
+    tokenBMint,
     tokenADepositAmount,
     tokenBDepositAmount,
     config.publicKey,

--- a/ts-client/src/examples/get_pool_info.ts
+++ b/ts-client/src/examples/get_pool_info.ts
@@ -1,25 +1,20 @@
-import {
-  Connection,
-  PublicKey,
-  Keypair,
-} from "@solana/web3.js";
-import BN from "bn.js";
+import { Connection, PublicKey, Keypair } from '@solana/web3.js';
+import BN from 'bn.js';
 import { Wallet, AnchorProvider, Program } from '@coral-xyz/anchor';
 import AmmImpl from '../amm';
 import { Amm as AmmIdl, IDL as AmmIDL } from '../amm/idl';
-import { PROGRAM_ID } from "../amm/constants";
-import fs from "fs";
-import os from 'os'
-
+import { PROGRAM_ID } from '../amm/constants';
+import fs from 'fs';
+import os from 'os';
 
 function loadKeypairFromFile(filename: string): Keypair {
-  const secret = JSON.parse(fs.readFileSync(filename.replace("~", os.homedir)).toString()) as number[];
+  const secret = JSON.parse(fs.readFileSync(filename.replace('~', os.homedir)).toString()) as number[];
   const secretKey = Uint8Array.from(secret);
   return Keypair.fromSecretKey(secretKey);
 }
-const payerKP = loadKeypairFromFile("~/.config/solana/id.json")
+const payerKP = loadKeypairFromFile('~/.config/solana/id.json');
 const payerWallet = new Wallet(payerKP);
-console.log("Wallet Address: %s \n", payerKP.publicKey);
+console.log('Wallet Address: %s \n', payerKP.publicKey);
 
 const mainnetConnection = new Connection('https://api.mainnet-beta.solana.com');
 const provider = new AnchorProvider(mainnetConnection, payerWallet, {
@@ -28,26 +23,34 @@ const provider = new AnchorProvider(mainnetConnection, payerWallet, {
 
 async function getPoolInfo(poolAddress: PublicKey) {
   const pool = await AmmImpl.create(provider.connection, poolAddress);
-  const poolInfo = pool.poolInfo
+  const poolInfo = pool.poolInfo;
 
-  console.log('Pool Address: %s', poolAddress.toString())
+  console.log('Pool Address: %s', poolAddress.toString());
   const poolTokenAddress = await pool.getPoolTokenMint();
-  console.log('Pool LP Token Mint Address: %s', poolTokenAddress.toString())
+  console.log('Pool LP Token Mint Address: %s', poolTokenAddress.toString());
   const LockedLpAmount = await pool.getLockedLpAmount();
-  console.log('Locked Lp Amount: %s', LockedLpAmount.toNumber())
+  console.log('Locked Lp Amount: %s', LockedLpAmount.toNumber());
   const lpSupply = await pool.getLpSupply();
-  console.log('Pool LP Supply: %s \n', lpSupply.toNumber() / Math.pow(10, pool.decimals))
+  console.log('Pool LP Supply: %s \n', lpSupply.toNumber() / Math.pow(10, pool.decimals));
 
-  console.log("tokenA %s Amount: %s ", pool.tokenA.address, poolInfo.tokenAAmount.toNumber() / Math.pow(10, pool.tokenA.decimals))
-  console.log("tokenB %s Amount: %s", pool.tokenB.address, poolInfo.tokenBAmount.toNumber() / Math.pow(10, pool.tokenB.decimals))
-  console.log("virtualPrice: %s", poolInfo.virtualPrice)
-  console.log("virtualPriceRaw to String: %s \n", poolInfo.virtualPriceRaw.toString())
+  console.log(
+    'tokenA %s Amount: %s ',
+    pool.tokenAMint.address,
+    poolInfo.tokenAAmount.toNumber() / Math.pow(10, pool.tokenAMint.decimals),
+  );
+  console.log(
+    'tokenB %s Amount: %s',
+    pool.tokenBMint.address,
+    poolInfo.tokenBAmount.toNumber() / Math.pow(10, pool.tokenBMint.decimals),
+  );
+  console.log('virtualPrice: %s', poolInfo.virtualPrice);
+  console.log('virtualPriceRaw to String: %s \n', poolInfo.virtualPriceRaw.toString());
 }
 
 async function main() {
   // mainnet-beta, SOL-USDC
-  const poolAddress = "6SWtsTzXrurtVWZdEHvnQdE9oM8tTtyg8rfEo3b4nM93"
+  const poolAddress = '6SWtsTzXrurtVWZdEHvnQdE9oM8tTtyg8rfEo3b4nM93';
   await getPoolInfo(new PublicKey(poolAddress));
 }
 
-main()
+main();

--- a/ts-client/src/examples/get_pool_info.ts
+++ b/ts-client/src/examples/get_pool_info.ts
@@ -27,14 +27,7 @@ const provider = new AnchorProvider(mainnetConnection, payerWallet, {
 });
 
 async function getPoolInfo(poolAddress: PublicKey) {
-  const ammProgram = new Program<AmmIdl>(AmmIDL, PROGRAM_ID, provider);
-  let poolState = await ammProgram.account.pool.fetch(poolAddress);
-  const tokenList = await fetch('https://token.jup.ag/all').then(res => res.json());
-  const tokenAInfo = tokenList.find(token => token.address === poolState.tokenAMint.toString());
-  const tokenBInfo = tokenList.find(token => token.address === poolState.tokenBMint.toString());
-
-  const pool = await AmmImpl.create(provider.connection, poolAddress, tokenAInfo, tokenBInfo);
-
+  const pool = await AmmImpl.create(provider.connection, poolAddress);
   const poolInfo = pool.poolInfo
 
   console.log('Pool Address: %s', poolAddress.toString())
@@ -45,8 +38,8 @@ async function getPoolInfo(poolAddress: PublicKey) {
   const lpSupply = await pool.getLpSupply();
   console.log('Pool LP Supply: %s \n', lpSupply.toNumber() / Math.pow(10, pool.decimals))
 
-  console.log("tokenA %s Amount: %s ", pool.tokenA.name, poolInfo.tokenAAmount.toNumber() / Math.pow(10, tokenAInfo.decimals))
-  console.log("tokenB %s Amount: %s", pool.tokenB.name, poolInfo.tokenBAmount.toNumber() / Math.pow(10, tokenBInfo.decimals))
+  console.log("tokenA %s Amount: %s ", pool.tokenA.address, poolInfo.tokenAAmount.toNumber() / Math.pow(10, pool.tokenA.decimals))
+  console.log("tokenB %s Amount: %s", pool.tokenB.address, poolInfo.tokenBAmount.toNumber() / Math.pow(10, pool.tokenB.decimals))
   console.log("virtualPrice: %s", poolInfo.virtualPrice)
   console.log("virtualPriceRaw to String: %s \n", poolInfo.virtualPriceRaw.toString())
 }

--- a/ts-client/src/examples/swap.ts
+++ b/ts-client/src/examples/swap.ts
@@ -25,28 +25,8 @@ const provider = new AnchorProvider(devnetConnection, payerWallet, {
   commitment: 'confirmed',
 });
 
-async function swap(poolAddress: PublicKey, swapAmount: BN, swapAtoB: boolean) {
-  let tokenAInfo = {
-    chainId: 103,
-    address: '9NGDi2tZtNmCCp8SVLKNuGjuWAVwNF3Vap5tT8km5er9',
-    decimals: 9,
-    name: '9NG',
-    symbol: '9NG',
-    logoURI:
-      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB/logo.svg',
-    tags: ['stablecoin'],
-  }
-  let tokenBInfo = {
-    chainId: 103,
-    address: 'So11111111111111111111111111111111111111112',
-    decimals: 9,
-    name: 'Wrapped SOL',
-    symbol: 'SOL',
-    logoURI:
-      'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png',
-  }
-
-  const pool = await AmmImpl.create(provider.connection, poolAddress, tokenAInfo, tokenBInfo);
+async function swap(poolAddress: PublicKey, swapAmount: BN, swapAtoB: boolean ) {
+  const pool = await AmmImpl.create(provider.connection, poolAddress);
   const poolInfo = pool.poolInfo
 
   const poolTokenAddress = await pool.getPoolTokenMint();
@@ -56,18 +36,18 @@ async function swap(poolAddress: PublicKey, swapAmount: BN, swapAtoB: boolean) {
   const LockedLpAmount = await pool.getLockedLpAmount();
   console.log('Locked Lp Amount: %s \n', LockedLpAmount.toNumber())
 
-  console.log("tokenA %s Amount: %s ", pool.tokenA.name, poolInfo.tokenAAmount.toNumber() / Math.pow(10, tokenAInfo.decimals))
-  console.log("tokenB %s Amount: %s ", pool.tokenB.name, poolInfo.tokenBAmount.toNumber() / Math.pow(10, tokenBInfo.decimals))
+  console.log("tokenA %s Amount: %s ", pool.tokenA.address, poolInfo.tokenAAmount.toNumber() / Math.pow(10, pool.tokenA.decimals))
+  console.log("tokenB %s Amount: %s ", pool.tokenB.address, poolInfo.tokenBAmount.toNumber() / Math.pow(10, pool.tokenB.decimals))
   console.log("virtualPrice: %s \n", poolInfo.virtualPrice)
 
-  let swapInToken = swapAtoB ? tokenAInfo : tokenBInfo;
-  let swapOuToken = swapAtoB ? tokenBInfo : tokenAInfo;
+  let swapInToken = swapAtoB ? pool.tokenA : pool.tokenB;
+  let swapOutToken = swapAtoB ? pool.tokenB : pool.tokenA;
   let inTokenMint = new PublicKey(swapInToken.address);
   let swapQuote: SwapQuote = pool.getSwapQuote(inTokenMint, swapAmount, 100);
   console.log("🚀 ~ swapQuote:");
-  console.log("Swap In %s, Amount %s ", swapInToken.name, swapQuote.swapInAmount.toNumber() / Math.pow(10, swapInToken.decimals))
-  console.log("Swap Out %s, Amount %s \n", swapOuToken.name, swapQuote.swapOutAmount.toNumber() / Math.pow(10, swapOuToken.decimals));
-  console.log("Fee of the Swap %s %s", swapQuote.fee.toNumber() / Math.pow(10, swapInToken.decimals), swapInToken.name)
+  console.log("Swap In %s, Amount %s ", swapInToken.address, swapQuote.swapInAmount.toNumber() / Math.pow(10, swapInToken.decimals))
+  console.log("Swap Out %s, Amount %s \n", swapOutToken.address, swapQuote.swapOutAmount.toNumber() / Math.pow(10, swapOutToken.decimals));
+  console.log("Fee of the Swap %s %s", swapQuote.fee.toNumber() / Math.pow(10, swapInToken.decimals), swapInToken.address)
   console.log("Price Impact of the Swap %s \n", swapQuote.priceImpact)
 
   console.log("Swapping...↔️ Please wait for a while😊☕️")
@@ -87,8 +67,8 @@ async function main() {
   // devnet, 9NG-SOL
   const poolAddress = "Bgf1Sy5kfeDgib4go4NgzHuZwek8wE8NZus56z6uizzi"
 
-  // swap 10 9NG token to SOL
-  // await swap(new PublicKey(poolAddress), new BN(10000_000_000), true);
+  // swap 5 9NG token to SOL
+  // await swap(new PublicKey(poolAddress), new BN(5000_000_000), true);
 
   // swap 0.01 SOL to 9NG token
   await swap(new PublicKey(poolAddress), new BN(10_000_000), false);

--- a/ts-client/src/examples/swap.ts
+++ b/ts-client/src/examples/swap.ts
@@ -1,56 +1,71 @@
-import {
-  Connection,
-  PublicKey,
-  Keypair,
-} from "@solana/web3.js";
-import BN from "bn.js";
+import { Connection, PublicKey, Keypair } from '@solana/web3.js';
+import BN from 'bn.js';
 import { Wallet, AnchorProvider, Program } from '@coral-xyz/anchor';
 import AmmImpl from '../amm';
-import fs from "fs";
-import os from 'os'
-import { SwapQuote } from "../amm/types";
-
+import fs from 'fs';
+import os from 'os';
+import { SwapQuote } from '../amm/types';
 
 function loadKeypairFromFile(filename: string): Keypair {
-  const secret = JSON.parse(fs.readFileSync(filename.replace("~", os.homedir)).toString()) as number[];
+  const secret = JSON.parse(fs.readFileSync(filename.replace('~', os.homedir)).toString()) as number[];
   const secretKey = Uint8Array.from(secret);
   return Keypair.fromSecretKey(secretKey);
 }
-const payerKP = loadKeypairFromFile("~/.config/solana/id.json")
+const payerKP = loadKeypairFromFile('~/.config/solana/id.json');
 const payerWallet = new Wallet(payerKP);
-console.log("Wallet Address: %s \n", payerKP.publicKey);
+console.log('Wallet Address: %s \n', payerKP.publicKey);
 
 const devnetConnection = new Connection('https://api.devnet.solana.com');
 const provider = new AnchorProvider(devnetConnection, payerWallet, {
   commitment: 'confirmed',
 });
 
-async function swap(poolAddress: PublicKey, swapAmount: BN, swapAtoB: boolean ) {
+async function swap(poolAddress: PublicKey, swapAmount: BN, swapAtoB: boolean) {
   const pool = await AmmImpl.create(provider.connection, poolAddress);
-  const poolInfo = pool.poolInfo
+  const poolInfo = pool.poolInfo;
 
   const poolTokenAddress = await pool.getPoolTokenMint();
-  console.log('Pool LP Token Mint Address: %s', poolTokenAddress.toString())
+  console.log('Pool LP Token Mint Address: %s', poolTokenAddress.toString());
   const lpSupply = await pool.getLpSupply();
-  console.log('Pool LP Supply: %s', lpSupply.toNumber() / Math.pow(10, pool.decimals))
+  console.log('Pool LP Supply: %s', lpSupply.toNumber() / Math.pow(10, pool.decimals));
   const LockedLpAmount = await pool.getLockedLpAmount();
-  console.log('Locked Lp Amount: %s \n', LockedLpAmount.toNumber())
+  console.log('Locked Lp Amount: %s \n', LockedLpAmount.toNumber());
 
-  console.log("tokenA %s Amount: %s ", pool.tokenA.address, poolInfo.tokenAAmount.toNumber() / Math.pow(10, pool.tokenA.decimals))
-  console.log("tokenB %s Amount: %s ", pool.tokenB.address, poolInfo.tokenBAmount.toNumber() / Math.pow(10, pool.tokenB.decimals))
-  console.log("virtualPrice: %s \n", poolInfo.virtualPrice)
+  console.log(
+    'tokenA %s Amount: %s ',
+    pool.tokenAMint.address,
+    poolInfo.tokenAAmount.toNumber() / Math.pow(10, pool.tokenAMint.decimals),
+  );
+  console.log(
+    'tokenB %s Amount: %s ',
+    pool.tokenBMint.address,
+    poolInfo.tokenBAmount.toNumber() / Math.pow(10, pool.tokenBMint.decimals),
+  );
+  console.log('virtualPrice: %s \n', poolInfo.virtualPrice);
 
-  let swapInToken = swapAtoB ? pool.tokenA : pool.tokenB;
-  let swapOutToken = swapAtoB ? pool.tokenB : pool.tokenA;
+  let swapInToken = swapAtoB ? pool.tokenAMint : pool.tokenBMint;
+  let swapOutToken = swapAtoB ? pool.tokenBMint : pool.tokenAMint;
   let inTokenMint = new PublicKey(swapInToken.address);
   let swapQuote: SwapQuote = pool.getSwapQuote(inTokenMint, swapAmount, 100);
-  console.log("🚀 ~ swapQuote:");
-  console.log("Swap In %s, Amount %s ", swapInToken.address, swapQuote.swapInAmount.toNumber() / Math.pow(10, swapInToken.decimals))
-  console.log("Swap Out %s, Amount %s \n", swapOutToken.address, swapQuote.swapOutAmount.toNumber() / Math.pow(10, swapOutToken.decimals));
-  console.log("Fee of the Swap %s %s", swapQuote.fee.toNumber() / Math.pow(10, swapInToken.decimals), swapInToken.address)
-  console.log("Price Impact of the Swap %s \n", swapQuote.priceImpact)
+  console.log('🚀 ~ swapQuote:');
+  console.log(
+    'Swap In %s, Amount %s ',
+    swapInToken.address,
+    swapQuote.swapInAmount.toNumber() / Math.pow(10, swapInToken.decimals),
+  );
+  console.log(
+    'Swap Out %s, Amount %s \n',
+    swapOutToken.address,
+    swapQuote.swapOutAmount.toNumber() / Math.pow(10, swapOutToken.decimals),
+  );
+  console.log(
+    'Fee of the Swap %s %s',
+    swapQuote.fee.toNumber() / Math.pow(10, swapInToken.decimals),
+    swapInToken.address,
+  );
+  console.log('Price Impact of the Swap %s \n', swapQuote.priceImpact);
 
-  console.log("Swapping...↔️ Please wait for a while😊☕️")
+  console.log('Swapping...↔️ Please wait for a while😊☕️');
 
   const swapTx = await pool.swap(
     payerWallet.publicKey,
@@ -60,12 +75,12 @@ async function swap(poolAddress: PublicKey, swapAmount: BN, swapAtoB: boolean ) 
   );
   const swapResult = await provider.sendAndConfirm(swapTx);
 
-  console.log('Swap Transaction Hash: %s ', swapResult)
+  console.log('Swap Transaction Hash: %s ', swapResult);
 }
 
 async function main() {
   // devnet, 9NG-SOL
-  const poolAddress = "Bgf1Sy5kfeDgib4go4NgzHuZwek8wE8NZus56z6uizzi"
+  const poolAddress = 'Bgf1Sy5kfeDgib4go4NgzHuZwek8wE8NZus56z6uizzi';
 
   // swap 5 9NG token to SOL
   // await swap(new PublicKey(poolAddress), new BN(5000_000_000), true);
@@ -74,4 +89,4 @@ async function main() {
   await swap(new PublicKey(poolAddress), new BN(10_000_000), false);
 }
 
-main()
+main();

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -18,10 +18,7 @@ const provider = new AnchorProvider(mainnetConnection, mockWallet, {
 async function swapQuote(poolAddress: PublicKey, swapAmount: BN, swapAtoB: boolean) {
   const ammProgram = new Program<AmmIdl>(AmmIDL, PROGRAM_ID, provider);
   let poolState = await ammProgram.account.pool.fetch(poolAddress);
-  const tokenList = await fetch('https://token.jup.ag/all').then(res => res.json());
-  const tokenAInfo = tokenList.find(token => token.address === poolState.tokenAMint.toString());
-  const tokenBInfo = tokenList.find(token => token.address === poolState.tokenBMint.toString());
-  const pool = await AmmImpl.create(provider.connection, poolAddress, tokenAInfo, tokenBInfo);
+  const pool = await AmmImpl.create(provider.connection, poolAddress);
   let inTokenMint = swapAtoB ? poolState.tokenAMint : poolState.tokenBMint;
   let swapQuote = pool.getSwapQuote(inTokenMint, swapAmount, 100);
   console.log("🚀 ~ swapQuote:", swapQuote);


### PR DESCRIPTION
-  refactor `AmmImpl.create()` to use only 2 arguments: provider, poolAddress
- use new `AmmImpl.create()` function in examples: swap, swap_quote, get_pool_info
- update `CHANGELOG.md`
- update vault-sdk to 2.0.0
- refactor types and functions to use tokenMint instead of tokenInfo
- provide address and decimals in 2 object: `tokenAMint` and `tokenBMint`
- differentiate `tokenMint` and `tokenAddress(`PublickKey Only)